### PR TITLE
add super hack to support undeclared polymorphic adapter fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [1.6.0] - August 12, 2021
+## [1.7.0] - August 14th, 2021
+
+### Added
+
+- Added ability to inject an emergency `UndeclaredField` in the event of certain polymorphic serializers and such
+
+## [1.6.0] - August 12th, 2021
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,21 @@ The intended purpose of `KompendiumField` is to offer field level overrides such
 The purpose of `KompendiumParam` is to provide supplemental information needed to properly assign the type of parameter 
 (cookie, header, query, path) as well as other parameter-level metadata. 
 
+### Undeclared Field
+
+There is also a final `UndeclaredField` annotation.  This should be used only in an absolutely emergency.  This annotation
+will allow you to inject a _single_ undeclared field that will be included as part of the schema. 
+
+Due to limitations in using repeated annotations, this can only be used once per class
+
+This is a complete hack, and is included for odd scenarios like kotlinx serialization polymorphic adapters that expect a 
+`type` field in order to perform their analysis.  
+
+Use this _only_ when **all** else fails
+
 ### Polymorphism
 
-Out of the box, Kompendium has support for sealed classes. At runtime, it will build a mapping of all available sub-classes
+Speaking of polymorphism... out of the box, Kompendium has support for sealed classes and interfaces. At runtime, it will build a mapping of all available sub-classes
 and build a spec that takes `anyOf` the implementations.  This is currently a weak point of the entire library, and 
 suggestions on better implementations are welcome 🤠
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Kompendium
-project.version=1.6.0
+project.version=1.7.0
 # Kotlin
 kotlin.code.style=official
 # Gradle

--- a/kompendium-core/src/main/kotlin/io/bkbn/kompendium/annotations/UndeclaredField.kt
+++ b/kompendium-core/src/main/kotlin/io/bkbn/kompendium/annotations/UndeclaredField.kt
@@ -2,7 +2,7 @@ package io.bkbn.kompendium.annotations
 
 import kotlin.reflect.KClass
 
-//@Retention(AnnotationRetention.RUNTIME)
+@Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @Repeatable
 annotation class UndeclaredField(val field: String, val clazz: KClass<*>)

--- a/kompendium-core/src/main/kotlin/io/bkbn/kompendium/annotations/UndeclaredField.kt
+++ b/kompendium-core/src/main/kotlin/io/bkbn/kompendium/annotations/UndeclaredField.kt
@@ -1,0 +1,8 @@
+package io.bkbn.kompendium.annotations
+
+import kotlin.reflect.KClass
+
+//@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+@Repeatable
+annotation class UndeclaredField(val field: String, val clazz: KClass<*>)

--- a/kompendium-core/src/test/kotlin/io/bkbn/kompendium/KompendiumTest.kt
+++ b/kompendium-core/src/test/kotlin/io/bkbn/kompendium/KompendiumTest.kt
@@ -43,6 +43,7 @@ import io.bkbn.kompendium.util.simpleGenericResponse
 import io.bkbn.kompendium.util.statusPageModule
 import io.bkbn.kompendium.util.statusPageMultiExceptions
 import io.bkbn.kompendium.util.trailingSlash
+import io.bkbn.kompendium.util.undeclaredType
 import io.bkbn.kompendium.util.withDefaultParameter
 import io.bkbn.kompendium.util.withExamples
 
@@ -552,6 +553,22 @@ internal class KompendiumTest {
 
       // expect
       val expected = getFileSnapshot("crazy_polymorphic_example.json").trim()
+      assertEquals(expected, json, "The received json spec should match the expected content")
+    }
+  }
+
+  @Test
+  fun `Can add an undeclared field`() {
+    withTestApplication({
+      kotlinxConfigModule()
+      docs()
+      undeclaredType()
+    }) {
+      // do
+      val json = handleRequest(HttpMethod.Get, "/openapi.json").response.content
+
+      // expect
+      val expected = getFileSnapshot("undeclared_field.json").trim()
       assertEquals(expected, json, "The received json spec should match the expected content")
     }
   }

--- a/kompendium-core/src/test/kotlin/io/bkbn/kompendium/util/TestModels.kt
+++ b/kompendium-core/src/test/kotlin/io/bkbn/kompendium/util/TestModels.kt
@@ -4,6 +4,7 @@ import java.util.UUID
 import io.bkbn.kompendium.annotations.KompendiumField
 import io.bkbn.kompendium.annotations.KompendiumParam
 import io.bkbn.kompendium.annotations.ParamType
+import io.bkbn.kompendium.annotations.UndeclaredField
 import java.math.BigDecimal
 import java.math.BigInteger
 
@@ -94,3 +95,11 @@ sealed interface Flibbity<T>
 
 data class Gibbity<T>(val a: T): Flibbity<T>
 data class Bibbity<T>(val b: String, val f: T) : Flibbity<T>
+
+enum class Hehe {
+  HAHA,
+  HOHO
+}
+
+@UndeclaredField("nowYouDont", Hehe::class)
+data class Mysterious(val nowYouSeeMe: String)

--- a/kompendium-core/src/test/kotlin/io/bkbn/kompendium/util/TestModules.kt
+++ b/kompendium-core/src/test/kotlin/io/bkbn/kompendium/util/TestModules.kt
@@ -340,6 +340,16 @@ fun Application.genericPolymorphicResponseMultipleImpls() {
   }
 }
 
+fun Application.undeclaredType() {
+  routing {
+    route("/test/polymorphic") {
+      notarizedGet(TestResponseInfo.undeclaredResponseType) {
+        call.respond(HttpStatusCode.OK, Mysterious("hi"))
+      }
+    }
+  }
+}
+
 fun Application.simpleGenericResponse() {
   routing {
     route("/test/polymorphic") {

--- a/kompendium-core/src/test/kotlin/io/bkbn/kompendium/util/TestResponseInfo.kt
+++ b/kompendium-core/src/test/kotlin/io/bkbn/kompendium/util/TestResponseInfo.kt
@@ -103,6 +103,11 @@ object TestResponseInfo {
     description = "Polymorphic with generics but like... crazier",
     responseInfo = simpleOkResponse()
   )
+  val undeclaredResponseType = GetInfo<Unit, Mysterious>(
+    summary = "spooky class",
+    description = "break this glass in scenario of emergency",
+    responseInfo = simpleOkResponse()
+  )
   val genericResponse = GetInfo<Unit, TestGeneric<Int>>(
     summary = "Single Generic",
     description = "Simple generic data class",

--- a/kompendium-core/src/test/resources/undeclared_field.json
+++ b/kompendium-core/src/test/resources/undeclared_field.json
@@ -1,0 +1,73 @@
+{
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "Test API",
+    "version" : "1.33.7",
+    "description" : "An amazing, fully-ish 😉 generated API spec",
+    "termsOfService" : "https://example.com",
+    "contact" : {
+      "name" : "Homer Simpson",
+      "url" : "https://gph.is/1NPUDiM",
+      "email" : "chunkylover53@aol.com"
+    },
+    "license" : {
+      "name" : "MIT",
+      "url" : "https://github.com/bkbnio/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers" : [ {
+    "url" : "https://myawesomeapi.com",
+    "description" : "Production instance of my API"
+  }, {
+    "url" : "https://staging.myawesomeapi.com",
+    "description" : "Where the fun stuff happens"
+  } ],
+  "paths" : {
+    "/test/polymorphic" : {
+      "get" : {
+        "tags" : [ ],
+        "summary" : "spooky class",
+        "description" : "break this glass in scenario of emergency",
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "A successful endeavor",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Mysterious"
+                }
+              }
+            }
+          }
+        },
+        "deprecated" : false
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "String" : {
+        "type" : "string"
+      },
+      "Hehe" : {
+        "type" : "string",
+        "enum" : [ "HAHA", "HOHO" ]
+      },
+      "Mysterious" : {
+        "type" : "object",
+        "properties" : {
+          "nowYouSeeMe" : {
+            "$ref" : "#/components/schemas/String"
+          },
+          "nowYouDont" : {
+            "$ref" : "#/components/schemas/Hehe"
+          }
+        }
+      }
+    },
+    "securitySchemes" : { }
+  },
+  "security" : [ ],
+  "tags" : [ ]
+}

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/Main.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/Main.kt
@@ -19,6 +19,7 @@ import io.bkbn.kompendium.playground.PlaygroundToC.testSingleGetInfo
 import io.bkbn.kompendium.playground.PlaygroundToC.testSingleGetInfoWithThrowable
 import io.bkbn.kompendium.playground.PlaygroundToC.testSinglePostInfo
 import io.bkbn.kompendium.playground.PlaygroundToC.testSinglePutInfo
+import io.bkbn.kompendium.playground.PlaygroundToC.testUndeclaredFields
 import io.bkbn.kompendium.routes.openApi
 import io.bkbn.kompendium.routes.redoc
 import io.bkbn.kompendium.swagger.swaggerUI
@@ -136,6 +137,11 @@ fun Application.mainModule() {
     route("/error") {
       notarizedGet(testSingleGetInfoWithThrowable) {
         error("bad things just happened")
+      }
+    }
+    route("/undeclared") {
+      notarizedGet(testUndeclaredFields) {
+        call.respondText { "hi" }
       }
     }
   }

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/Models.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/Models.kt
@@ -3,6 +3,7 @@ package io.bkbn.kompendium.playground
 import io.bkbn.kompendium.annotations.KompendiumField
 import io.bkbn.kompendium.annotations.KompendiumParam
 import io.bkbn.kompendium.annotations.ParamType
+import io.bkbn.kompendium.annotations.UndeclaredField
 import org.joda.time.DateTime
 
 data class ExampleParams(
@@ -33,3 +34,11 @@ data class ExceptionResponse(val message: String)
 data class ExampleCreatedResponse(val id: Int, val c: String)
 
 data class DateTimeWrapper(val dt: DateTime)
+
+enum class Testerino {
+  First,
+  Second
+}
+
+@UndeclaredField("type", Testerino::class)
+data class SimpleYetMysterious(val exists: Boolean)

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/PlaygroundToC.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/PlaygroundToC.kt
@@ -109,4 +109,13 @@ object PlaygroundToC {
     ),
     securitySchemes = setOf("basic")
   )
+  val testUndeclaredFields = MethodInfo.GetInfo<Unit, SimpleYetMysterious>(
+    summary = "Tests adding undeclared fields",
+    description = "vvv mysterious",
+    tags = setOf("mysterious"),
+    responseInfo = ResponseInfo(
+      status = HttpStatusCode.OK,
+      description = "good tings"
+    )
+  )
 }


### PR DESCRIPTION
# Description

Adds in a super hacky approach to allowing a singular undeclared field for a provided class.  Super niche, should only be used in case of emergency (like undeclared polymorphic adapter fields 😭 )

Closes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added tests and confirmed in playground 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated the CHANGELOG and bumped the version
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
