### PR TITLE
fix: bumped swagger version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,24 @@
 ## Unreleased
 
 ### Added
-- Custom Type example to playground
 
 ### Changed
-- Cleaned up and broke out handlers into separate classes
-- Serializer cleanup
-- Tests now run against Jackson, Gson and kotlinx on every run
 
 ### Remove
 
 ---
 
 ## Released
+
+## [2.0.4] - February 10th, 2022
+### Added
+- Custom Type example to playground
+
+### Changed
+- Cleaned up and broke out handlers into separate classes
+- Serializer cleanup
+- Tests now run against Jackson, Gson and kotlinx on every run
+- Swagger UI bumped from v3 to v4
 
 ## [2.0.3] - February 7th, 2022
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Kompendium
-project.version=2.0.3
+project.version=2.0.4
 # Kotlin
 kotlin.code.style=official
 # Gradle

--- a/kompendium-core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
+++ b/kompendium-core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
@@ -36,7 +36,7 @@ fun Routing.swagger(pageTitle: String = "Docs", specUrl: String = "/openapi.json
             content = "width=device-width, initial-scale=1"
           }
           link {
-            href = "https://unpkg.com/swagger-ui-dist@3.12.1/swagger-ui.css"
+            href = "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css"
             rel = "stylesheet"
           }
         }
@@ -45,10 +45,10 @@ fun Routing.swagger(pageTitle: String = "Docs", specUrl: String = "/openapi.json
             id = "swagger-ui"
           }
           script {
-            src = "https://unpkg.com/swagger-ui-dist@3.12.1/swagger-ui-standalone-preset.js"
+            src = "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-standalone-preset.js"
           }
           script {
-            src = "https://unpkg.com/swagger-ui-dist@3.12.1/swagger-ui-bundle.js"
+            src = "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-bundle.js"
           }
           unsafe {
             +"""

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/AuthPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/AuthPlayground.kt
@@ -7,6 +7,7 @@ import io.bkbn.kompendium.core.Notarized.notarizedGet
 import io.bkbn.kompendium.core.metadata.ResponseInfo
 import io.bkbn.kompendium.core.metadata.method.GetInfo
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
 import io.bkbn.kompendium.playground.AuthPlaygroundToC.simpleAuthenticatedGet
 import io.bkbn.kompendium.playground.util.Util
 import io.ktor.application.Application
@@ -23,6 +24,7 @@ import io.ktor.serialization.json
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 /**
  * Application entrypoint.  Run this and head on over to `localhost:8081/docs`
@@ -39,7 +41,11 @@ fun main() {
 // Application Module
 private fun Application.mainModule() {
   install(ContentNegotiation) {
-    json()
+    json(Json {
+      serializersModule = KompendiumSerializersModule.module
+      encodeDefaults = true
+      explicitNulls = false
+    })
   }
   install(Kompendium) {
     spec = Util.baseSpec

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/BasicPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/BasicPlayground.kt
@@ -15,6 +15,8 @@ import io.bkbn.kompendium.core.metadata.method.DeleteInfo
 import io.bkbn.kompendium.core.metadata.method.GetInfo
 import io.bkbn.kompendium.core.metadata.method.PostInfo
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
+import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
 import io.bkbn.kompendium.playground.BasicModels.BasicParameters
 import io.bkbn.kompendium.playground.BasicModels.BasicRequest
 import io.bkbn.kompendium.playground.BasicModels.BasicResponse
@@ -37,6 +39,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import java.util.UUID
 
 /**
@@ -55,7 +58,11 @@ fun main() {
 private fun Application.mainModule() {
   // Installs Simple JSON Content Negotiation
   install(ContentNegotiation) {
-    json()
+    json(Json {
+      serializersModule = KompendiumSerializersModule.module
+      encodeDefaults = true
+      explicitNulls = false
+    })
   }
   // Installs the Kompendium Plugin and sets up baseline server metadata
   install(Kompendium) {
@@ -66,6 +73,8 @@ private fun Application.mainModule() {
     // This adds ReDoc support at the `/docs` endpoint.
     // By default, it will point at the `/openapi.json` created by Kompendium
     redoc(pageTitle = "Simple API Docs")
+    // You can also use swagger!
+    swagger(pageTitle = "Swaggerlicious")
     // Kompendium infers the route path from the Ktor Route.  This will show up as the root path `/`
     notarizedGet(simpleGetExample) {
       call.respond(HttpStatusCode.OK, BasicResponse(c = UUID.randomUUID().toString()))

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/ConstraintPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/ConstraintPlayground.kt
@@ -23,6 +23,7 @@ import io.bkbn.kompendium.core.metadata.ResponseInfo
 import io.bkbn.kompendium.core.metadata.method.GetInfo
 import io.bkbn.kompendium.core.metadata.method.PostInfo
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
 import io.bkbn.kompendium.playground.ConstrainedModels.ConstrainedParams
 import io.bkbn.kompendium.playground.ConstrainedModels.ConstrainedRequest
 import io.bkbn.kompendium.playground.ConstrainedModels.ConstrainedResponse
@@ -40,6 +41,7 @@ import io.ktor.serialization.json
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 fun main() {
@@ -54,7 +56,11 @@ fun main() {
 private fun Application.mainModule() {
   // Installs Simple JSON Content Negotiation
   install(ContentNegotiation) {
-    json()
+    json(Json {
+      serializersModule = KompendiumSerializersModule.module
+      encodeDefaults = true
+      explicitNulls = false
+    })
   }
   // Installs the Kompendium Plugin and sets up baseline server metadata
   install(Kompendium) {

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/ExceptionPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/ExceptionPlayground.kt
@@ -6,6 +6,7 @@ import io.bkbn.kompendium.core.metadata.ExceptionInfo
 import io.bkbn.kompendium.core.metadata.ResponseInfo
 import io.bkbn.kompendium.core.metadata.method.GetInfo
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
 import io.bkbn.kompendium.playground.ExceptionPlaygroundToC.simpleGetExample
 import io.bkbn.kompendium.playground.util.Util
 import io.ktor.application.Application
@@ -21,6 +22,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kotlin.reflect.typeOf
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import java.time.LocalDateTime
 
 // Application Entrypoint
@@ -36,7 +38,11 @@ fun main() {
 private fun Application.mainModule() {
   // Installs Simple JSON Content Negotiation
   install(ContentNegotiation) {
-    json()
+    json(Json {
+      serializersModule = KompendiumSerializersModule.module
+      encodeDefaults = true
+      explicitNulls = false
+    })
   }
   // Installs the Kompendium Plugin and sets up baseline server metadata
   install(Kompendium) {

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/GenericPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/GenericPlayground.kt
@@ -5,6 +5,7 @@ import io.bkbn.kompendium.core.Notarized.notarizedGet
 import io.bkbn.kompendium.core.metadata.ResponseInfo
 import io.bkbn.kompendium.core.metadata.method.GetInfo
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
 import io.bkbn.kompendium.playground.GenericPlaygroundToC.simpleGenericGet
 import io.bkbn.kompendium.playground.util.Util
 import io.ktor.application.Application
@@ -18,6 +19,7 @@ import io.ktor.serialization.json
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 /**
  * Application entrypoint.  Run this and head on over to `localhost:8081/docs`
@@ -35,7 +37,11 @@ fun main() {
 private fun Application.mainModule() {
   // Installs Simple JSON Content Negotiation
   install(ContentNegotiation) {
-    json()
+    json(Json {
+      serializersModule = KompendiumSerializersModule.module
+      encodeDefaults = true
+      explicitNulls = false
+    })
   }
   // Installs the Kompendium Plugin and sets up baseline server metadata
   install(Kompendium) {

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/LocationPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/LocationPlayground.kt
@@ -7,6 +7,7 @@ import io.bkbn.kompendium.core.metadata.ResponseInfo
 import io.bkbn.kompendium.core.metadata.method.GetInfo
 import io.bkbn.kompendium.core.routes.redoc
 import io.bkbn.kompendium.locations.NotarizedLocation.notarizedGet
+import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
 import io.bkbn.kompendium.playground.LocationsToC.ohBoiUCrazy
 import io.bkbn.kompendium.playground.LocationsToC.testLocation
 import io.bkbn.kompendium.playground.LocationsToC.testNestLocation
@@ -24,6 +25,7 @@ import io.ktor.serialization.json
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 /**
  * Application entrypoint.  Run this and head on over to `localhost:8081/docs`
@@ -39,7 +41,11 @@ fun main() {
 
 private fun Application.mainModule() {
   install(ContentNegotiation) {
-    json()
+    json(Json {
+      serializersModule = KompendiumSerializersModule.module
+      encodeDefaults = true
+      explicitNulls = false
+    })
   }
   install(Kompendium) {
     spec = Util.baseSpec

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/PolymorphicPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/PolymorphicPlayground.kt
@@ -5,6 +5,7 @@ import io.bkbn.kompendium.core.Notarized.notarizedGet
 import io.bkbn.kompendium.core.metadata.ResponseInfo
 import io.bkbn.kompendium.core.metadata.method.GetInfo
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
 import io.bkbn.kompendium.playground.PolymorphicPlaygroundToC.polymorphicExample
 import io.bkbn.kompendium.playground.util.Util
 import io.ktor.application.Application
@@ -18,6 +19,7 @@ import io.ktor.serialization.json
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 /**
  * Application entrypoint.  Run this and head on over to `localhost:8081/docs`
@@ -34,7 +36,11 @@ fun main() {
 private fun Application.mainModule() {
   // Installs Simple JSON Content Negotiation
   install(ContentNegotiation) {
-    json()
+    json(Json {
+      serializersModule = KompendiumSerializersModule.module
+      encodeDefaults = true
+      explicitNulls = false
+    })
   }
   // Installs the Kompendium Plugin and sets up baseline server metadata
   install(Kompendium) {

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/RecursionPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/RecursionPlayground.kt
@@ -6,6 +6,7 @@ import io.bkbn.kompendium.core.Notarized.notarizedGet
 import io.bkbn.kompendium.core.metadata.ResponseInfo
 import io.bkbn.kompendium.core.metadata.method.GetInfo
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
 import io.bkbn.kompendium.playground.util.Util
 import io.ktor.application.Application
 import io.ktor.application.call
@@ -19,6 +20,7 @@ import io.ktor.serialization.json
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 enum class ColumnMode {
   NULLABLE,
@@ -58,7 +60,11 @@ fun main() {
 
 private fun Application.mainModule() {
   install(ContentNegotiation) {
-    json()
+    json(Json {
+      serializersModule = KompendiumSerializersModule.module
+      encodeDefaults = true
+      explicitNulls = false
+    })
   }
   install(Kompendium) {
     spec = Util.baseSpec

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/SwaggerPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/SwaggerPlayground.kt
@@ -3,6 +3,7 @@ package io.bkbn.kompendium.playground
 import io.bkbn.kompendium.core.Kompendium
 import io.bkbn.kompendium.core.Notarized.notarizedGet
 import io.bkbn.kompendium.core.routes.swagger
+import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
 import io.bkbn.kompendium.playground.util.Util
 import io.ktor.application.Application
 import io.ktor.application.call
@@ -15,6 +16,7 @@ import io.ktor.serialization.json
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import io.ktor.webjars.Webjars
+import kotlinx.serialization.json.Json
 import java.util.UUID
 
 /**
@@ -33,7 +35,11 @@ fun main() {
 private fun Application.mainModule() {
   // Installs Simple JSON Content Negotiation
   install(ContentNegotiation) {
-    json()
+    json(Json {
+      serializersModule = KompendiumSerializersModule.module
+      encodeDefaults = true
+      explicitNulls = false
+    })
   }
   install(Webjars)
   // Installs the Kompendium Plugin and sets up baseline server metadata


### PR DESCRIPTION
# Description

Couple of minor fixes
- Swagger UI now on V4 and correctly shows example bodies
- Playground examples now have correct serializer attached
- Prep for 2.0.4 release 

Closes #184 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation 
- [ ] Chore

# How Has This Been Tested?

From local playground example

<img width="832" alt="Screen Shot 2022-02-10 at 8 30 17 AM" src="https://user-images.githubusercontent.com/5607577/153418001-1c49a613-d2a2-4500-b738-7c38aed68c2c.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
