### PR TITLE
feat: allow for overriding openapi endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- Ability to override serializer via custom route
 
 ### Changed
 

--- a/kompendium-core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestHelpers.kt
+++ b/kompendium-core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestHelpers.kt
@@ -35,7 +35,7 @@ object TestHelpers {
    * exists as expected, and that the content matches the expected blob found in the specified file
    * @param snapshotName The snapshot file to retrieve from the resources folder
    */
-  private fun TestApplicationEngine.compareOpenAPISpec(snapshotName: String) {
+  fun TestApplicationEngine.compareOpenAPISpec(snapshotName: String) {
     // act
     handleRequest(HttpMethod.Get, OPEN_API_ENDPOINT).apply {
       // assert

--- a/kompendium-core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestModules.kt
+++ b/kompendium-core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestModules.kt
@@ -3,19 +3,14 @@ package io.bkbn.kompendium.core.fixtures
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.SerializationFeature
 import io.bkbn.kompendium.core.Kompendium
+import io.bkbn.kompendium.core.fixtures.TestSpecs.defaultSpec
 import io.bkbn.kompendium.core.routes.redoc
-import io.bkbn.kompendium.oas.OpenApiSpec
-import io.bkbn.kompendium.oas.info.Contact
-import io.bkbn.kompendium.oas.info.Info
-import io.bkbn.kompendium.oas.info.License
-import io.bkbn.kompendium.oas.server.Server
 import io.ktor.application.Application
 import io.ktor.application.install
 import io.ktor.features.ContentNegotiation
 import io.ktor.http.ContentType
 import io.ktor.jackson.jackson
 import io.ktor.routing.routing
-import java.net.URI
 
 fun Application.docs() {
   routing {
@@ -34,32 +29,6 @@ fun Application.jacksonConfigModule() {
 
 fun Application.kompendium() {
   install(Kompendium) {
-    spec = OpenApiSpec(
-      info = Info(
-        title = "Test API",
-        version = "1.33.7",
-        description = "An amazing, fully-ish 😉 generated API spec",
-        termsOfService = URI("https://example.com"),
-        contact = Contact(
-          name = "Homer Simpson",
-          email = "chunkylover53@aol.com",
-          url = URI("https://gph.is/1NPUDiM")
-        ),
-        license = License(
-          name = "MIT",
-          url = URI("https://github.com/bkbnio/kompendium/blob/main/LICENSE")
-        )
-      ),
-      servers = mutableListOf(
-        Server(
-          url = URI("https://myawesomeapi.com"),
-          description = "Production instance of my API"
-        ),
-        Server(
-          url = URI("https://staging.myawesomeapi.com"),
-          description = "Where the fun stuff happens"
-        )
-      )
-    )
+    spec = defaultSpec()
   }
 }

--- a/kompendium-core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestSpecs.kt
+++ b/kompendium-core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestSpecs.kt
@@ -1,0 +1,40 @@
+package io.bkbn.kompendium.core.fixtures
+
+import io.bkbn.kompendium.oas.OpenApiSpec
+import io.bkbn.kompendium.oas.info.Contact
+import io.bkbn.kompendium.oas.info.Info
+import io.bkbn.kompendium.oas.info.License
+import io.bkbn.kompendium.oas.server.Server
+import java.net.URI
+
+object TestSpecs {
+  val defaultSpec: () -> OpenApiSpec = {
+    OpenApiSpec(
+      info = Info(
+        title = "Test API",
+        version = "1.33.7",
+        description = "An amazing, fully-ish 😉 generated API spec",
+        termsOfService = URI("https://example.com"),
+        contact = Contact(
+          name = "Homer Simpson",
+          email = "chunkylover53@aol.com",
+          url = URI("https://gph.is/1NPUDiM")
+        ),
+        license = License(
+          name = "MIT",
+          url = URI("https://github.com/bkbnio/kompendium/blob/main/LICENSE")
+        )
+      ),
+      servers = mutableListOf(
+        Server(
+          url = URI("https://myawesomeapi.com"),
+          description = "Production instance of my API"
+        ),
+        Server(
+          url = URI("https://staging.myawesomeapi.com"),
+          description = "Where the fun stuff happens"
+        )
+      )
+    )
+  }
+}

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/SerializerOverridePlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/SerializerOverridePlayground.kt
@@ -1,0 +1,85 @@
+package io.bkbn.kompendium.playground
+
+import io.bkbn.kompendium.core.Kompendium
+import io.bkbn.kompendium.core.Notarized.notarizedGet
+import io.bkbn.kompendium.core.metadata.ResponseInfo
+import io.bkbn.kompendium.core.metadata.method.GetInfo
+import io.bkbn.kompendium.core.routes.swagger
+import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
+import io.bkbn.kompendium.playground.Customization.customSerializer
+import io.bkbn.kompendium.playground.SerializerOverridePlaygroundToC.getExample
+import io.bkbn.kompendium.playground.util.Util
+import io.ktor.application.Application
+import io.ktor.application.call
+import io.ktor.application.install
+import io.ktor.features.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.response.respond
+import io.ktor.response.respondText
+import io.ktor.routing.get
+import io.ktor.routing.route
+import io.ktor.routing.routing
+import io.ktor.serialization.json
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+fun main() {
+  embeddedServer(
+    Netty,
+    port = 8081,
+    module = Application::mainModule
+  ).start(wait = true)
+}
+
+private fun Application.mainModule() {
+  install(ContentNegotiation) {
+    json(Json {
+      encodeDefaults = false
+    })
+  }
+  install(Kompendium) {
+    spec = Util.baseSpec
+    openApiJson = { spec ->
+      route("/openapi.json") {
+        get {
+          call.respondText { customSerializer.encodeToString(spec) }
+        }
+      }
+    }
+  }
+  routing {
+    swagger(pageTitle = "Docs")
+    notarizedGet(getExample) {
+      call.respond(HttpStatusCode.OK, SerializerOverrideModel.OhYeaCoolData(null))
+    }
+  }
+}
+
+object SerializerOverridePlaygroundToC {
+  val getExample = GetInfo<Unit, SerializerOverrideModel.OhYeaCoolData>(
+    summary = "Overriding the serializer",
+    description = "Pretty neat!",
+    responseInfo = ResponseInfo(
+      status = HttpStatusCode.OK,
+      description = "This means everything went as expected!",
+      examples = mapOf("demo" to SerializerOverrideModel.OhYeaCoolData(null))
+    ),
+    tags = setOf("Custom")
+  )
+}
+
+object SerializerOverrideModel {
+  @Serializable
+  data class OhYeaCoolData(val num: Int?, val test: String = "gonezo")
+}
+
+object Customization {
+  val customSerializer = Json {
+    serializersModule = KompendiumSerializersModule.module
+    encodeDefaults = true
+    explicitNulls = false
+  }
+}


### PR DESCRIPTION
# Description

Enables users who need to leverage custom serializers to explicitly override the `/openapi.json` endpoint to fit their needs

Closes #185 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation 
- [ ] Chore

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated the CHANGELOG in the `Unreleased` section
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
