### PR TITLE
Fix (#194) to support Location classes located in other non-location classes (e.g. inside Object)

### DIFF
--- a/kompendium-annotations/src/main/kotlin/io/bkbn/kompendium/annotations/constraint/Format.kt
+++ b/kompendium-annotations/src/main/kotlin/io/bkbn/kompendium/annotations/constraint/Format.kt
@@ -1,5 +1,5 @@
 package io.bkbn.kompendium.annotations.constraint
 
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.TYPE)
 annotation class Format(val format: String)

--- a/kompendium-core/src/main/kotlin/io/bkbn/kompendium/core/Kontent.kt
+++ b/kompendium-core/src/main/kotlin/io/bkbn/kompendium/core/Kontent.kt
@@ -1,22 +1,24 @@
 package io.bkbn.kompendium.core
 
-import io.bkbn.kompendium.core.metadata.SchemaMap
+import io.bkbn.kompendium.annotations.constraint.Format
 import io.bkbn.kompendium.core.handler.CollectionHandler
 import io.bkbn.kompendium.core.handler.EnumHandler
 import io.bkbn.kompendium.core.handler.MapHandler
 import io.bkbn.kompendium.core.handler.ObjectHandler
+import io.bkbn.kompendium.core.metadata.SchemaMap
 import io.bkbn.kompendium.core.util.Helpers.logged
 import io.bkbn.kompendium.oas.schema.FormattedSchema
 import io.bkbn.kompendium.oas.schema.SimpleSchema
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
-import kotlin.reflect.full.createType
-import kotlin.reflect.full.isSubclassOf
-import kotlin.reflect.typeOf
 import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.createType
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.typeOf
 
 /**
  * Responsible for generating the schema map that is used to power all object references across the API Spec.
@@ -81,7 +83,10 @@ object Kontent {
       Long::class -> cache[clazz.simpleName!!] = FormattedSchema("int64", "integer")
       Double::class -> cache[clazz.simpleName!!] = FormattedSchema("double", "number")
       Float::class -> cache[clazz.simpleName!!] = FormattedSchema("float", "number")
-      String::class -> cache[clazz.simpleName!!] = SimpleSchema("string")
+      String::class -> cache[clazz.simpleName!!] = SimpleSchema(
+        "string",
+        format = type.findAnnotation<Format>()?.format
+      )
       Boolean::class -> cache[clazz.simpleName!!] = SimpleSchema("boolean")
       UUID::class -> cache[clazz.simpleName!!] = FormattedSchema("uuid", "string")
       BigDecimal::class -> cache[clazz.simpleName!!] = FormattedSchema("double", "number")

--- a/kompendium-core/src/main/kotlin/io/bkbn/kompendium/core/Kontent.kt
+++ b/kompendium-core/src/main/kotlin/io/bkbn/kompendium/core/Kontent.kt
@@ -9,16 +9,16 @@ import io.bkbn.kompendium.core.metadata.SchemaMap
 import io.bkbn.kompendium.core.util.Helpers.logged
 import io.bkbn.kompendium.oas.schema.FormattedSchema
 import io.bkbn.kompendium.oas.schema.SimpleSchema
-import org.slf4j.LoggerFactory
-import java.math.BigDecimal
-import java.math.BigInteger
-import java.util.UUID
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.typeOf
+import org.slf4j.LoggerFactory
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.UUID
 
 /**
  * Responsible for generating the schema map that is used to power all object references across the API Spec.

--- a/kompendium-core/src/test/kotlin/io/bkbn/kompendium/core/KompendiumTest.kt
+++ b/kompendium-core/src/test/kotlin/io/bkbn/kompendium/core/KompendiumTest.kt
@@ -16,6 +16,7 @@ import io.bkbn.kompendium.core.util.defaultParameter
 import io.bkbn.kompendium.core.util.exampleParams
 import io.bkbn.kompendium.core.util.exclusiveMinMax
 import io.bkbn.kompendium.core.util.formattedParam
+import io.bkbn.kompendium.core.util.formattedType
 import io.bkbn.kompendium.core.util.freeFormObject
 import io.bkbn.kompendium.core.util.genericPolymorphicResponse
 import io.bkbn.kompendium.core.util.genericPolymorphicResponseMultipleImpls
@@ -273,6 +274,9 @@ class KompendiumTest : DescribeSpec({
     }
     it("Can set a minimum and maximum number of properties on a free-form type") {
       openApiTestAllSerializers("min_max_free_form.json") { minMaxFreeForm() }
+    }
+    it("Can add a custom format to a collection type") {
+      openApiTestAllSerializers("formatted_array_item_type.json") { formattedType() }
     }
   }
   describe("Free Form") {

--- a/kompendium-core/src/test/kotlin/io/bkbn/kompendium/core/util/TestModules.kt
+++ b/kompendium-core/src/test/kotlin/io/bkbn/kompendium/core/util/TestModules.kt
@@ -595,3 +595,13 @@ fun Application.exampleParams() {
     }
   }
 }
+
+fun Application.formattedType() {
+  routing {
+    route("/test/formatted_type") {
+      notarizedPost(TestResponseInfo.formattedArrayItemType) {
+        call.respond(HttpStatusCode.OK, TestResponse("hi"))
+      }
+    }
+  }
+}

--- a/kompendium-core/src/test/resources/formatted_array_item_type.json
+++ b/kompendium-core/src/test/resources/formatted_array_item_type.json
@@ -1,0 +1,95 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Test API",
+    "version": "1.33.7",
+    "description": "An amazing, fully-ish 😉 generated API spec",
+    "termsOfService": "https://example.com",
+    "contact": {
+      "name": "Homer Simpson",
+      "url": "https://gph.is/1NPUDiM",
+      "email": "chunkylover53@aol.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/bkbnio/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://myawesomeapi.com",
+      "description": "Production instance of my API"
+    },
+    {
+      "url": "https://staging.myawesomeapi.com",
+      "description": "Where the fun stuff happens"
+    }
+  ],
+  "paths": {
+    "/test/formatted_type": {
+      "post": {
+        "tags": [],
+        "summary": "formatted array item type",
+        "description": "Cool stuff",
+        "parameters": [],
+        "requestBody": {
+          "description": "cool",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FormattedArrayItemType"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A successful endeavor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestResponse"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FormattedArrayItemType": {
+        "properties": {
+          "a": {
+            "items": {
+              "type": "string",
+              "format": "binary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "a"
+        ],
+        "type": "object"
+      },
+      "TestResponse": {
+        "properties": {
+          "c": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "c"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": []
+}

--- a/kompendium-core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestModels.kt
+++ b/kompendium-core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestModels.kt
@@ -95,6 +95,10 @@ data class FormattedString(
   val a: String
 )
 
+data class FormattedArrayItemType(
+  val a: List<@Format("binary") String>
+)
+
 data class MinMaxString(
   @MinLength(42)
   @MaxLength(1337)

--- a/kompendium-core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestResponseInfo.kt
+++ b/kompendium-core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestResponseInfo.kt
@@ -293,5 +293,12 @@ object TestResponseInfo {
     )
   )
 
+  val formattedArrayItemType = PostInfo<Unit, FormattedArrayItemType, TestResponse>(
+      summary = "formatted array item type",
+      description = "Cool stuff",
+      responseInfo = simpleOkResponse(),
+      requestInfo = RequestInfo("cool")
+  )
+
   private fun <T> simpleOkResponse() = ResponseInfo<T>(HttpStatusCode.OK, "A successful endeavor")
 }

--- a/kompendium-locations/src/main/kotlin/io/bkbn/kompendium/locations/LocationMethodParser.kt
+++ b/kompendium-locations/src/main/kotlin/io/bkbn/kompendium/locations/LocationMethodParser.kt
@@ -50,7 +50,7 @@ object LocationMethodParser : IMethodParser {
   fun KClass<*>.calculateLocationPath(suffix: String = ""): String {
     val locationAnnotation = this.findAnnotation<Location>()
     require(locationAnnotation != null) { "Location annotation must be present to leverage notarized location api" }
-    val parent = this.java.declaringClass?.kotlin
+    val parent = this.java.declaringClass?.kotlin?.takeIf { it.hasAnnotation<Location>() }
     val newSuffix = locationAnnotation.path.plus(suffix)
     return when (parent) {
       null -> newSuffix

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/LocationPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/LocationPlayground.kt
@@ -69,7 +69,7 @@ private fun Application.mainModule() {
 }
 
 private object LocationsToC {
-  val testLocation = GetInfo<TestLocations, LocationModels.ExampleResponse>(
+  val testLocation = GetInfo<TestLocationsParent.TestLocations, LocationModels.ExampleResponse>(
     summary = "Shallow",
     description = "Ez Pz Lemon Squeezy",
     responseInfo = ResponseInfo(
@@ -77,7 +77,7 @@ private object LocationsToC {
       description = "Great!"
     )
   )
-  val testNestLocation = GetInfo<TestLocations.NestedTestLocations, LocationModels.ExampleResponse>(
+  val testNestLocation = GetInfo<TestLocationsParent.TestLocations.NestedTestLocations, LocationModels.ExampleResponse>(
     summary = "Nested",
     description = "Gettin' scary",
     responseInfo = ResponseInfo(
@@ -85,7 +85,7 @@ private object LocationsToC {
       description = "Hmmm"
     )
   )
-  val ohBoiUCrazy = GetInfo<TestLocations.NestedTestLocations.OhBoiUCrazy, LocationModels.ExampleResponse>(
+  val ohBoiUCrazy = GetInfo<TestLocationsParent.TestLocations.NestedTestLocations.OhBoiUCrazy, LocationModels.ExampleResponse>(
     summary = "Example Deeply Nested",
     description = "We deep now",
     responseInfo = ResponseInfo(
@@ -99,23 +99,28 @@ private object LocationsToC {
 // For more info make sure to read through the Ktor location docs
 // Additionally, make sure to note that even though we define the locations here, we still must annotate fields
 // with KompendiumParam!!!
-@Location("test/{name}")
-data class TestLocations(
-  @Param(ParamType.PATH)
-  val name: String,
-) {
-  @Location("/spaghetti")
-  data class NestedTestLocations(
-    @Param(ParamType.QUERY)
-    val idk: Int,
-    val parent: TestLocations
+object TestLocationsParent {
+
+  @Location("test/{name}")
+  data class TestLocations(
+    @Param(ParamType.PATH)
+    val name: String,
   ) {
-    @Location("/hehe/{madness}")
-    data class OhBoiUCrazy(
-      @Param(ParamType.PATH)
-      val madness: Boolean,
-      val parent: NestedTestLocations
-    )
+
+    @Location("/spaghetti")
+    data class NestedTestLocations(
+      @Param(ParamType.QUERY)
+      val idk: Int,
+      val parent: TestLocations
+    ) {
+
+      @Location("/hehe/{madness}")
+      data class OhBoiUCrazy(
+        @Param(ParamType.PATH)
+        val madness: Boolean,
+        val parent: NestedTestLocations
+      )
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes #194 

Implementation notes:
- Stops processing parent classes for path calculation if they are not @Location annotated

