### PR TITLE
Fix (#194) to support Location classes located in other non-location classes (e.g. inside Object)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fixed support Location classes located in other non-location classes
 
 ### Added
 

--- a/kompendium-locations/src/main/kotlin/io/bkbn/kompendium/locations/LocationMethodParser.kt
+++ b/kompendium-locations/src/main/kotlin/io/bkbn/kompendium/locations/LocationMethodParser.kt
@@ -50,7 +50,7 @@ object LocationMethodParser : IMethodParser {
   fun KClass<*>.calculateLocationPath(suffix: String = ""): String {
     val locationAnnotation = this.findAnnotation<Location>()
     require(locationAnnotation != null) { "Location annotation must be present to leverage notarized location api" }
-    val parent = this.java.declaringClass?.kotlin
+    val parent = this.java.declaringClass?.kotlin?.takeIf { it.hasAnnotation<Location>() }
     val newSuffix = locationAnnotation.path.plus(suffix)
     return when (parent) {
       null -> newSuffix

--- a/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/KompendiumLocationsTest.kt
+++ b/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/KompendiumLocationsTest.kt
@@ -5,7 +5,7 @@ import io.bkbn.kompendium.locations.util.locationsConfig
 import io.bkbn.kompendium.locations.util.notarizedDeleteNestedLocation
 import io.bkbn.kompendium.locations.util.notarizedDeleteSimpleLocation
 import io.bkbn.kompendium.locations.util.notarizedGetNestedLocation
-import io.bkbn.kompendium.locations.util.notarizedGetNestedLocationClass
+import io.bkbn.kompendium.locations.util.notarizedGetNestedLocationFromNonLocationClass
 import io.bkbn.kompendium.locations.util.notarizedGetSimpleLocation
 import io.bkbn.kompendium.locations.util.notarizedPostNestedLocation
 import io.bkbn.kompendium.locations.util.notarizedPostSimpleLocation
@@ -73,9 +73,9 @@ class KompendiumLocationsTest : DescribeSpec({
     }
     it("Can notarize a get with a nested location nested in a non-location class") {
       // act
-      openApiTestAllSerializers("notarized_get_nested_location.json") {
+      openApiTestAllSerializers("notarized_get_nested_location_from_non_location_class.json") {
         locationsConfig()
-        notarizedGetNestedLocationClass()
+        notarizedGetNestedLocationFromNonLocationClass()
       }
     }
   }

--- a/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/KompendiumLocationsTest.kt
+++ b/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/KompendiumLocationsTest.kt
@@ -5,6 +5,7 @@ import io.bkbn.kompendium.locations.util.locationsConfig
 import io.bkbn.kompendium.locations.util.notarizedDeleteNestedLocation
 import io.bkbn.kompendium.locations.util.notarizedDeleteSimpleLocation
 import io.bkbn.kompendium.locations.util.notarizedGetNestedLocation
+import io.bkbn.kompendium.locations.util.notarizedGetNestedLocationClass
 import io.bkbn.kompendium.locations.util.notarizedGetSimpleLocation
 import io.bkbn.kompendium.locations.util.notarizedPostNestedLocation
 import io.bkbn.kompendium.locations.util.notarizedPostSimpleLocation
@@ -68,6 +69,13 @@ class KompendiumLocationsTest : DescribeSpec({
       openApiTestAllSerializers("notarized_delete_nested_location.json") {
         locationsConfig()
         notarizedDeleteNestedLocation()
+      }
+    }
+    it("Can notarize a get with a nested location nested in a non-location class") {
+      // act
+      openApiTestAllSerializers("notarized_get_nested_location.json") {
+        locationsConfig()
+        notarizedGetNestedLocationClass()
       }
     }
   }

--- a/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestModels.kt
+++ b/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestModels.kt
@@ -10,7 +10,7 @@ data class SimpleLoc(@Param(ParamType.PATH) val name: String) {
   data class NestedLoc(@Param(ParamType.QUERY) val isCool: Boolean, val parent: SimpleLoc)
 }
 
-object LocationHolderClass {
+object NonLocationObject {
   @Location("/test/{name}")
   data class SimpleLoc(@Param(ParamType.PATH) val name: String) {
     @Location("/nesty")

--- a/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestModels.kt
+++ b/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestModels.kt
@@ -10,5 +10,13 @@ data class SimpleLoc(@Param(ParamType.PATH) val name: String) {
   data class NestedLoc(@Param(ParamType.QUERY) val isCool: Boolean, val parent: SimpleLoc)
 }
 
+object LocationHolderClass {
+  @Location("/test/{name}")
+  data class SimpleLoc(@Param(ParamType.PATH) val name: String) {
+    @Location("/nesty")
+    data class NestedLoc(@Param(ParamType.QUERY) val isCool: Boolean, val parent: SimpleLoc)
+  }
+}
+
 data class SimpleResponse(val result: Boolean)
 data class SimpleRequest(val input: String)

--- a/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestModules.kt
+++ b/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestModules.kt
@@ -96,10 +96,10 @@ fun Application.notarizedDeleteNestedLocation() {
   }
 }
 
-fun Application.notarizedGetNestedLocationClass() {
+fun Application.notarizedGetNestedLocationFromNonLocationClass() {
   routing {
     route("/test") {
-      notarizedGet(TestResponseInfo.testGetNestedLocationClass) {
+      notarizedGet(TestResponseInfo.testGetNestedLocationFromNonLocationClass) {
         call.respondText { "hey dude ‼️ congratz on the get request" }
       }
     }

--- a/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestModules.kt
+++ b/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestModules.kt
@@ -95,3 +95,13 @@ fun Application.notarizedDeleteNestedLocation() {
     }
   }
 }
+
+fun Application.notarizedGetNestedLocationClass() {
+  routing {
+    route("/test") {
+      notarizedGet(TestResponseInfo.testGetNestedLocationClass) {
+        call.respondText { "hey dude ‼️ congratz on the get request" }
+      }
+    }
+  }
+}

--- a/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestResponseInfo.kt
+++ b/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestResponseInfo.kt
@@ -86,7 +86,7 @@ object TestResponseInfo {
     )
   )
 
-  val testGetNestedLocationClass = GetInfo<LocationHolderClass.SimpleLoc.NestedLoc, SimpleResponse>(
+  val testGetNestedLocationFromNonLocationClass = GetInfo<NonLocationObject.SimpleLoc.NestedLoc, SimpleResponse>(
     summary = "Location Test",
     description = "A cool test",
     responseInfo = ResponseInfo(

--- a/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestResponseInfo.kt
+++ b/kompendium-locations/src/test/kotlin/io/bkbn/kompendium/locations/util/TestResponseInfo.kt
@@ -1,6 +1,5 @@
 package io.bkbn.kompendium.locations.util
 
-import io.bkbn.kompendium.core.metadata.method.MethodInfo
 import io.bkbn.kompendium.core.metadata.RequestInfo
 import io.bkbn.kompendium.core.metadata.ResponseInfo
 import io.bkbn.kompendium.core.metadata.method.DeleteInfo
@@ -79,6 +78,15 @@ object TestResponseInfo {
     )
   )
   val testDeleteNestedLocation = DeleteInfo<SimpleLoc.NestedLoc, SimpleResponse>(
+    summary = "Location Test",
+    description = "A cool test",
+    responseInfo = ResponseInfo(
+      status = HttpStatusCode.OK,
+      description = "A successful endeavor"
+    )
+  )
+
+  val testGetNestedLocationClass = GetInfo<LocationHolderClass.SimpleLoc.NestedLoc, SimpleResponse>(
     summary = "Location Test",
     description = "A cool test",
     responseInfo = ResponseInfo(

--- a/kompendium-locations/src/test/resources/notarized_get_nested_location_from_non_location_class.json
+++ b/kompendium-locations/src/test/resources/notarized_get_nested_location_from_non_location_class.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Test API",
+    "version": "1.33.7",
+    "description": "An amazing, fully-ish 😉 generated API spec",
+    "termsOfService": "https://example.com",
+    "contact": {
+      "name": "Homer Simpson",
+      "url": "https://gph.is/1NPUDiM",
+      "email": "chunkylover53@aol.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/bkbnio/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://myawesomeapi.com",
+      "description": "Production instance of my API"
+    },
+    {
+      "url": "https://staging.myawesomeapi.com",
+      "description": "Where the fun stuff happens"
+    }
+  ],
+  "paths": {
+    "/test/test/{name}/nesty": {
+      "get": {
+        "tags": [],
+        "summary": "Location Test",
+        "description": "A cool test",
+        "parameters": [
+          {
+            "name": "isCool",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "required": true,
+            "deprecated": false
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "deprecated": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful endeavor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleResponse"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SimpleResponse": {
+        "properties": {
+          "result": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "result"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": []
+}

--- a/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/LocationPlayground.kt
+++ b/kompendium-playground/src/main/kotlin/io/bkbn/kompendium/playground/LocationPlayground.kt
@@ -69,7 +69,7 @@ private fun Application.mainModule() {
 }
 
 private object LocationsToC {
-  val testLocation = GetInfo<TestLocations, LocationModels.ExampleResponse>(
+  val testLocation = GetInfo<TestLocationsParent.TestLocations, LocationModels.ExampleResponse>(
     summary = "Shallow",
     description = "Ez Pz Lemon Squeezy",
     responseInfo = ResponseInfo(
@@ -77,7 +77,7 @@ private object LocationsToC {
       description = "Great!"
     )
   )
-  val testNestLocation = GetInfo<TestLocations.NestedTestLocations, LocationModels.ExampleResponse>(
+  val testNestLocation = GetInfo<TestLocationsParent.TestLocations.NestedTestLocations, LocationModels.ExampleResponse>(
     summary = "Nested",
     description = "Gettin' scary",
     responseInfo = ResponseInfo(
@@ -85,7 +85,7 @@ private object LocationsToC {
       description = "Hmmm"
     )
   )
-  val ohBoiUCrazy = GetInfo<TestLocations.NestedTestLocations.OhBoiUCrazy, LocationModels.ExampleResponse>(
+  val ohBoiUCrazy = GetInfo<TestLocationsParent.TestLocations.NestedTestLocations.OhBoiUCrazy, LocationModels.ExampleResponse>(
     summary = "Example Deeply Nested",
     description = "We deep now",
     responseInfo = ResponseInfo(
@@ -99,23 +99,28 @@ private object LocationsToC {
 // For more info make sure to read through the Ktor location docs
 // Additionally, make sure to note that even though we define the locations here, we still must annotate fields
 // with KompendiumParam!!!
-@Location("test/{name}")
-data class TestLocations(
-  @Param(ParamType.PATH)
-  val name: String,
-) {
-  @Location("/spaghetti")
-  data class NestedTestLocations(
-    @Param(ParamType.QUERY)
-    val idk: Int,
-    val parent: TestLocations
+object TestLocationsParent {
+
+  @Location("test/{name}")
+  data class TestLocations(
+    @Param(ParamType.PATH)
+    val name: String,
   ) {
-    @Location("/hehe/{madness}")
-    data class OhBoiUCrazy(
-      @Param(ParamType.PATH)
-      val madness: Boolean,
-      val parent: NestedTestLocations
-    )
+
+    @Location("/spaghetti")
+    data class NestedTestLocations(
+      @Param(ParamType.QUERY)
+      val idk: Int,
+      val parent: TestLocations
+    ) {
+
+      @Location("/hehe/{madness}")
+      data class OhBoiUCrazy(
+        @Param(ParamType.PATH)
+        val madness: Boolean,
+        val parent: NestedTestLocations
+      )
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/bkbnio/kompendium/issues/194

Implementation notes:
- Stops processing parent classes for path calculation if they are not `@Location` annotated