### PR TITLE
fix(content-type): set content-type for webjar resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix content type of files served from swagger webjar
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Fix content type of files served from swagger webjar
+- Set content type of files served from swagger webjar
 
 ### Added
 

--- a/kompendium-swagger-ui/src/main/kotlin/io/bkbn/kompendium/swagger/SwaggerWebJarUtils.kt
+++ b/kompendium-swagger-ui/src/main/kotlin/io/bkbn/kompendium/swagger/SwaggerWebJarUtils.kt
@@ -1,6 +1,8 @@
 package io.bkbn.kompendium.swagger
 
 import io.ktor.features.NotFoundException
+import io.ktor.http.ContentType
+import io.ktor.http.defaultForFilePath
 import io.ktor.http.content.ByteArrayContent
 import java.net.URL
 import org.webjars.WebJarAssetLocator
@@ -10,10 +12,14 @@ internal fun WebJarAssetLocator.getSwaggerResource(path: String): URL =
     ?: throw NotFoundException("Resource not found: $path")
 
 internal fun WebJarAssetLocator.getSwaggerResourceContent(path: String): ByteArrayContent =
-  ByteArrayContent(getSwaggerResource(path).readBytes())
+    ByteArrayContent(
+        contentType = ContentType.defaultForFilePath(path),
+        bytes = getSwaggerResource(path).readBytes()
+    )
 
 internal fun WebJarAssetLocator.getSwaggerInitializerContent(jsConfig: JsConfig): ByteArrayContent = ByteArrayContent(
-    getSwaggerResource(path = "swagger-initializer.js").readText()
+    contentType = ContentType.Application.JavaScript,
+    bytes = getSwaggerResource(path = "swagger-initializer.js").readText()
       .replaceFirst("url: \"https://petstore.swagger.io/v2/swagger.json\",", "urls: ${jsConfig.getSpecUrlsProps()},")
       .replaceFirst("deepLinking: true", jsConfig.toJsProps())
       .let { content ->

--- a/kompendium-swagger-ui/src/test/kotlin/io/bkbn/kompendium/swagger/SwaggerUiTest.kt
+++ b/kompendium-swagger-ui/src/test/kotlin/io/bkbn/kompendium/swagger/SwaggerUiTest.kt
@@ -7,6 +7,7 @@ import io.bkbn.kompendium.swagger.TestHelpers.compareRedirect
 import io.bkbn.kompendium.swagger.TestHelpers.compareResource
 import io.bkbn.kompendium.swagger.TestHelpers.withSwaggerApplication
 import io.kotest.core.spec.style.DescribeSpec
+import io.ktor.http.ContentType
 
 class SwaggerUiTest: DescribeSpec ({
 
@@ -20,7 +21,7 @@ class SwaggerUiTest: DescribeSpec ({
 
         it ("Can return original: index.html") {
             withSwaggerApplication {
-                compareResource(TEST_SWAGGER_UI_INDEX, listOf(
+                compareResource(TEST_SWAGGER_UI_INDEX, ContentType.Text.Html, listOf(
                     "<title>Swagger UI</title>",
                     "<div id=\"swagger-ui\"></div>",
                     "src=\"./swagger-initializer.js\""
@@ -30,7 +31,7 @@ class SwaggerUiTest: DescribeSpec ({
 
         it("Can return generated: swagger-initializer.js") {
             withSwaggerApplication {
-                compareResource(TEST_SWAGGER_UI_INIT_JS, listOf(
+                compareResource(TEST_SWAGGER_UI_INIT_JS, ContentType.Application.JavaScript, listOf(
                     "url: '/openapi.json', name: 'My API v1'",
                     "url: '/openapi.json', name: 'My API v2'",
                     "defaultModelExpandDepth: 4",

--- a/kompendium-swagger-ui/src/test/kotlin/io/bkbn/kompendium/swagger/TestHelpers.kt
+++ b/kompendium-swagger-ui/src/test/kotlin/io/bkbn/kompendium/swagger/TestHelpers.kt
@@ -90,8 +90,8 @@ object TestHelpers {
       override fun test(value: TestApplicationResponse): MatcherResult {
         return MatcherResult(
           value.contentType().match(contentType),
-          { "Response should have ContentType $contentType= but was ${value.contentType()}" },
-          { "Response should not have ContentType $contentType" }
+          { "Response should have ContentType matching $contentType but was ${value.contentType()}" },
+          { "Response should not have ContentType matching $contentType" }
         )
       }
     }


### PR DESCRIPTION
# Description
Setting the `Content-Type` header when responding with resources from the SwaggerUI webjar.

Without explicitly setting a content-type some proxy-serveres will automagically inject `Content-Type: text/plain` into the response-headers. Which in turn instructs the browser to not parse css, js etc.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Copy/Pasted portions of `kompendium-swagger-ui`  into existing codebase, and verified that the swagger-page correctly loads after deploy the application behind a reverse proxy.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

Marked as draft since I had some issues with the build locally, and need to further investigate and check the other boxes.