### PR TITLE
fix: spec and docs behind auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Can now put redoc route behind authentication
 
 ### Remove
 

--- a/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Redoc.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Redoc.kt
@@ -3,7 +3,7 @@ package io.bkbn.kompendium.core.routes
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.html.respondHtml
-import io.ktor.server.routing.Routing
+import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import kotlinx.html.body
@@ -20,7 +20,7 @@ import kotlinx.html.unsafe
  * @param pageTitle Webpage title you wish to be displayed on your docs
  * @param specUrl url to point ReDoc to the OpenAPI json document
  */
-fun Routing.redoc(pageTitle: String = "Docs", specUrl: String = "/openapi.json") {
+fun Route.redoc(pageTitle: String = "Docs", specUrl: String = "/openapi.json") {
   route("/docs") {
     get {
       call.respondHtml(HttpStatusCode.OK) {

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/HiddenDocsPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/HiddenDocsPlayground.kt
@@ -1,5 +1,6 @@
 package io.bkbn.kompendium.playground
 
+import io.bkbn.kompendium.core.attribute.KompendiumAttributes
 import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.plugin.NotarizedRoute
@@ -25,6 +26,7 @@ import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.application
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
@@ -66,6 +68,15 @@ private fun Application.mainModule() {
         )
       )
     )
+    openApiJson = {
+      authenticate("basic") {
+        route("/openapi.json") {
+          get {
+            call.respond(HttpStatusCode.OK, this@route.application.attributes[KompendiumAttributes.openApiSpec])
+          }
+        }
+      }
+    }
   }
   routing {
     authenticate("basic") {

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/HiddenDocsPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/HiddenDocsPlayground.kt
@@ -80,7 +80,6 @@ private fun Application.mainModule() {
   }
   routing {
     authenticate("basic") {
-      // Put our API docs behind basic auth
       redoc(pageTitle = "Simple API Docs")
       route("/{id}") {
         idDocumentation()

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/HiddenDocsPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/HiddenDocsPlayground.kt
@@ -68,8 +68,9 @@ private fun Application.mainModule() {
     )
   }
   routing {
-    redoc(pageTitle = "Simple API Docs")
     authenticate("basic") {
+      // Put our API docs behind basic auth
+      redoc(pageTitle = "Simple API Docs")
       route("/{id}") {
         idDocumentation()
         get {


### PR DESCRIPTION
# Description

Allows for redoc to be placed behind authentication.  Also creates a playground example showcasing how to achieve this

Closes #277 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation 
- [ ] Chore

# How Has This Been Tested?

Playground example added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
