### PR TITLE
fix: Remove print statements for examples

### DIFF
--- a/core/src/main/kotlin/io/bkbn/kompendium/core/metadata/RequestInfo.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/metadata/RequestInfo.kt
@@ -33,7 +33,6 @@ class RequestInfo private constructor(
 
     fun examples(vararg e: Pair<String, Any>) = apply {
       this.examples = e.toMap().mapValues { (_, v) -> MediaType.Example(v) }
-      println(this.examples)
     }
 
     fun build() = RequestInfo(

--- a/core/src/main/kotlin/io/bkbn/kompendium/core/metadata/ResponseInfo.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/metadata/ResponseInfo.kt
@@ -40,7 +40,6 @@ class ResponseInfo private constructor(
 
     fun examples(vararg e: Pair<String, Any>) = apply {
       this.examples = e.toMap().mapValues { (_, v) -> MediaType.Example(v) }
-      println(this.examples)
     }
 
     fun build() = ResponseInfo(


### PR DESCRIPTION
# Description

Remove the `println()` statements which caused the serialized examples to be printed on application start.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
