### PR TITLE
Add string type for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Enum types are now generated with `type: string` to facilitate certain codegen tools (e.g. Orval)
+
 ### Changed
 
 ### Remove

--- a/core/src/test/resources/T0008__complex_type.json
+++ b/core/src/test/resources/T0008__complex_type.json
@@ -127,7 +127,8 @@
             "enum": [
               "ONE",
               "TWO"
-            ]
+            ],
+            "type": "string"
           }
         },
         "required": [

--- a/core/src/test/resources/T0037__nullable_enum_field.json
+++ b/core/src/test/resources/T0037__nullable_enum_field.json
@@ -65,7 +65,8 @@
                 "enum": [
                   "YES",
                   "NO"
-                ]
+                ],
+                "type": "string"
               }
             ]
           }

--- a/core/src/test/resources/T0040__nested_generic_multiple_type_params.json
+++ b/core/src/test/resources/T0040__nested_generic_multiple_type_params.json
@@ -60,7 +60,8 @@
             "enum": [
               "ONE",
               "TWO"
-            ]
+            ],
+            "type": "string"
           }
         },
         "required": [

--- a/core/src/test/resources/T0042__simple_recursive.json
+++ b/core/src/test/resources/T0042__simple_recursive.json
@@ -64,7 +64,8 @@
               "NULLABLE",
               "REQUIRED",
               "REPEATED"
-            ]
+            ],
+            "type": "string"
           },
           "name": {
             "type": "string"

--- a/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/definition/EnumDefinition.kt
+++ b/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/definition/EnumDefinition.kt
@@ -4,5 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class EnumDefinition(
-  val enum: Set<String>
+  val enum: Set<String>,
+  val type: String? = null
 ) : JsonSchema

--- a/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/definition/JsonSchema.kt
+++ b/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/definition/JsonSchema.kt
@@ -27,6 +27,7 @@ sealed interface JsonSchema {
         is NullableDefinition -> NullableDefinition.serializer().serialize(encoder, value)
         is OneOfDefinition -> OneOfDefinition.serializer().serialize(encoder, value)
         is AnyOfDefinition -> AnyOfDefinition.serializer().serialize(encoder, value)
+        else -> error("Unknown JsonSchema type: ${value::class.simpleName}")
       }
     }
   }

--- a/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/handler/EnumHandler.kt
+++ b/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/handler/EnumHandler.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KType
 object EnumHandler {
   fun handle(type: KType, clazz: KClass<*>): JsonSchema {
     val options = clazz.java.enumConstants.map { it.toString() }.toSet()
-    val definition = EnumDefinition(enum = options)
+    val definition = EnumDefinition(enum = options, type = "string")
     return when (type.isMarkedNullable) {
       true -> OneOfDefinition(NullableDefinition(), definition)
       false -> definition

--- a/json-schema/src/test/resources/T0007__simple_enum.json
+++ b/json-schema/src/test/resources/T0007__simple_enum.json
@@ -1,3 +1,4 @@
 {
-  "enum": [ "ONE", "TWO" ]
+  "enum": [ "ONE", "TWO" ],
+  "type": "string"
 }

--- a/json-schema/src/test/resources/T0008__nullable_enum.json
+++ b/json-schema/src/test/resources/T0008__nullable_enum.json
@@ -7,7 +7,8 @@
       "enum": [
         "ONE",
         "TWO"
-      ]
+      ],
+      "type": "string"
     }
   ]
 }


### PR DESCRIPTION
# Description

Some code generation tools expect a type to be provided with enums, e.g. https://github.com/anymaniax/orval/issues/605
This PR adds a `type: string` to all enums.

Closes #364

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Updated unit tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
