### PR TITLE
feat: add support for NotarizedRouteResources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add support for Resources plugin scoped to routes
+
 ### Changed
 
 ### Remove

--- a/docs/plugins/notarized_resources.md
+++ b/docs/plugins/notarized_resources.md
@@ -58,3 +58,58 @@ Here, the `resources` property is a map of `KClass<*>` to `ResourceMetadata` ins
 
 > ⚠️ If you try to map a class that is not annotated with the ktor `@Resource` annotation, you will get a runtime
 > exception!
+
+## NotarizedRouteResources
+
+If resources are used within nested routes, the `NotarizedResources()` definition will not know of the preceding route prefixes. In this case, you can use `NotarizedRouteResources()`, similar to the regular `NotarizedRoute()`:
+
+```kotlin
+@Serializable
+@Resource("/list/{name}/page/{page}")
+data class Listing(val name: String, val page: Int)
+
+private fun Application.mainModule() {
+  install(Resources)
+  install(NotarizedApplication()) {
+    spec = baseSpec
+  }
+  route("/api") {
+    routeResourcesDocumentation()
+    get<Listing> { listing ->
+      call.respondText("Listing ${listing.name}, page ${listing.page}")
+    }
+  }
+}
+
+private fun Route.routeResourcesDocumentation() {
+  install(NotarizedRouteResources()) {
+    resources = mapOf(
+      Listing::class to NotarizedRouteResources.ResourceMetadata(
+        parameters = listOf(
+          Parameter(
+            name = "name",
+            `in` = Parameter.Location.path,
+            schema = TypeDefinition.STRING
+          ),
+          Parameter(
+            name = "page",
+            `in` = Parameter.Location.path,
+            schema = TypeDefinition.INT
+          )
+        ),
+        get = GetInfo.builder {
+          summary("Get user by id")
+          description("A very neat endpoint!")
+          response {
+            responseCode(HttpStatusCode.OK)
+            responseType<ExampleResponse>()
+            description("Will return whether or not the user is real 😱")
+          }
+        }
+      ),
+    )
+  }
+}
+```
+
+In this case, the generated path will be `/api/list/{name}/page/{page}`, combining the route prefix with the path in the resource.

--- a/resources/src/main/kotlin/io/bkbn/kompendium/resources/NotarizedResources.kt
+++ b/resources/src/main/kotlin/io/bkbn/kompendium/resources/NotarizedResources.kt
@@ -56,6 +56,12 @@ object NotarizedResources {
       v.patch?.addToSpec(path, spec, v, serializableReader)
 
       val resource = k.getResourcesFromClass()
+      require(spec.paths[resource] == null) {
+        """
+          The specified path $resource has already been documented!
+          Please make sure that all notarized paths are unique
+        """.trimIndent()
+      }
       spec.paths[resource] = path
     }
   }

--- a/resources/src/test/resources/T0003__resources_in_route.json
+++ b/resources/src/test/resources/T0003__resources_in_route.json
@@ -1,0 +1,124 @@
+{
+  "openapi": "3.1.0",
+  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+  "info": {
+    "title": "Test API",
+    "version": "1.33.7",
+    "description": "An amazing, fully-ish 😉 generated API spec",
+    "termsOfService": "https://example.com",
+    "contact": {
+      "name": "Homer Simpson",
+      "url": "https://gph.is/1NPUDiM",
+      "email": "chunkylover53@aol.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/bkbnio/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://myawesomeapi.com",
+      "description": "Production instance of my API"
+    },
+    {
+      "url": "https://staging.myawesomeapi.com",
+      "description": "Where the fun stuff happens"
+    }
+  ],
+  "paths": {
+    "/api/type/{name}/edit": {
+      "get": {
+        "tags": [],
+        "summary": "Edit",
+        "description": "example resource",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "does great things",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestResponse"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "parameters": [
+        {
+          "name": "name",
+          "in": "path",
+          "schema": {
+            "type": "string"
+          },
+          "required": true,
+          "deprecated": false
+        }
+      ]
+    },
+    "/api/type/{name}/other/{page}": {
+      "get": {
+        "tags": [],
+        "summary": "Other",
+        "description": "example resource",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "does great things",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestResponse"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "parameters": [
+        {
+          "name": "name",
+          "in": "path",
+          "schema": {
+            "type": "string"
+          },
+          "required": true,
+          "deprecated": false
+        },
+        {
+          "name": "page",
+          "in": "path",
+          "schema": {
+            "type": "number",
+            "format": "int32"
+          },
+          "required": true,
+          "deprecated": false
+        }
+      ]
+    }
+  },
+  "webhooks": {},
+  "components": {
+    "schemas": {
+      "TestResponse": {
+        "type": "object",
+        "properties": {
+          "c": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "c"
+        ]
+      }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": []
+}


### PR DESCRIPTION
# Description

For resources in nested routes, there was no way to generate the correct path.
Now, with NotarizedRouteResources, one can do this, combining the syntax of
NotarizedRoute with the mapping in NotarizedResources.

Closes #370

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation

# How Has This Been Tested?

Added a new unit test for NotarizedRouteResources

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
