### PR TITLE
Reintroduce Swagger Compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add support for swagger documentation
+
 ### Changed
 
 ### Remove

--- a/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
@@ -17,10 +17,13 @@ import kotlinx.html.unsafe
 
 /**
  * Provides an out-of-the-box route to view docs using Swagger
+ * @see <a href="https://swagger.io/specification/">Swagger OpenApi Specification</a>
+ * for the latest supported open api version.
  * @param pageTitle Webpage title you wish to be displayed on your docs
- * @param specUrl url to point Swagger to the OpenAPI json document
  */
 fun Route.swagger(pageTitle: String = "Docs", specUrl: String = "/openapi.json") {
+  val swaggerVersion = "4.15.5"
+
   route("/swagger-ui") {
     get {
       call.respondHtml {
@@ -36,7 +39,7 @@ fun Route.swagger(pageTitle: String = "Docs", specUrl: String = "/openapi.json")
             content = "width=device-width, initial-scale=1"
           }
           link {
-            href = "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css"
+            href = "https://unpkg.com/swagger-ui-dist@$swaggerVersion/swagger-ui.css"
             rel = "stylesheet"
           }
         }
@@ -45,15 +48,14 @@ fun Route.swagger(pageTitle: String = "Docs", specUrl: String = "/openapi.json")
             id = "swagger-ui"
           }
           script {
-            src = "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-standalone-preset.js"
+            src = "https://unpkg.com/swagger-ui-dist@$swaggerVersion/swagger-ui-standalone-preset.js"
           }
           script {
-            src = "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-bundle.js"
+            src = "https://unpkg.com/swagger-ui-dist@$swaggerVersion/swagger-ui-bundle.js"
           }
           unsafe {
             +"""
               <script>
-
                 window.onload = function () {
                   // Build a system
                   const ui = SwaggerUIBundle({

--- a/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
@@ -1,0 +1,81 @@
+package io.bkbn.kompendium.core.routes
+
+import io.ktor.server.application.call
+import io.ktor.server.html.respondHtml
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import kotlinx.html.body
+import kotlinx.html.div
+import kotlinx.html.head
+import kotlinx.html.id
+import kotlinx.html.link
+import kotlinx.html.meta
+import kotlinx.html.script
+import kotlinx.html.title
+import kotlinx.html.unsafe
+
+/**
+ * Provides an out-of-the-box route to view docs using Swagger
+ * @param pageTitle Webpage title you wish to be displayed on your docs
+ * @param specUrl url to point Swagger to the OpenAPI json document
+ */
+fun Route.swagger(pageTitle: String = "Docs", specUrl: String = "/openapi.json") {
+  route("/swagger-ui") {
+    get {
+      call.respondHtml {
+        head {
+          title {
+            +pageTitle
+          }
+          meta {
+            charset = "utf-8"
+          }
+          meta {
+            name = "viewport"
+            content = "width=device-width, initial-scale=1"
+          }
+          link {
+            href = "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css"
+            rel = "stylesheet"
+          }
+        }
+        body {
+          div {
+            id = "swagger-ui"
+          }
+          script {
+            src = "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-standalone-preset.js"
+          }
+          script {
+            src = "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-bundle.js"
+          }
+          unsafe {
+            +"""
+              <script>
+
+                window.onload = function () {
+                  // Build a system
+                  const ui = SwaggerUIBundle({
+                    url: "$specUrl",
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
+                    presets: [
+                      SwaggerUIBundle.presets.apis,
+                      SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                      SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                    layout: "StandaloneLayout",
+                  })
+                  window.ui = ui
+                }
+              </script>
+            """.trimIndent()
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

Reintroduce swagger functionality that existed in v2.3.5 but was removed in v3.0.0. See [Swagger.kt@2.3.5](https://github.com/bkbnio/kompendium/blob/v2.3.5/kompendium-core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I ran a local version of the playground where `swagger()` gets called , but set the `openapi` value in the `OpenApiSpec` to "3.0.3" since swagger doesn't support 3.1.0 yet.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
