### PR TITLE
reintroduce swagger compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add support for swagger documentation
+
 ### Changed
 
 ### Remove

--- a/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Redoc.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Redoc.kt
@@ -18,7 +18,7 @@ import kotlinx.html.unsafe
 /**
  * Provides an out-of-the-box route to view docs using ReDoc on the specified [path].
  * @param pageTitle Webpage title you wish to be displayed on your docs
- * @param route path to docs resource
+ * @param path path to docs resource
  * @param specUrl url to point ReDoc to the OpenAPI json document
  */
 fun Route.redoc(pageTitle: String = "Docs", path: String = "/docs", specUrl: String = "/openapi.json") {

--- a/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
@@ -28,7 +28,7 @@ fun Route.swagger(
   pageTitle: String = "Docs",
   path: String = "/swagger-ui",
   specUrl: String = "/openapi.json",
-  swaggerVersion: String = "4.17.0"
+  swaggerVersion: String = "5.0.0-alpha.0"
 ) {
   route(path) {
     get {

--- a/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
@@ -28,8 +28,10 @@ fun Route.swagger(
   pageTitle: String = "Docs",
   path: String = "/swagger-ui",
   specUrl: String = "/openapi.json",
-  swaggerVersion: String = "5.0.0-alpha.0"
+  swaggerVersion: String? = null
 ) {
+  val swaggerVersionSuffix = if (swaggerVersion == null) "" else "@$swaggerVersion"
+
   route(path) {
     get {
       call.respondHtml {
@@ -45,7 +47,7 @@ fun Route.swagger(
             content = "width=device-width, initial-scale=1"
           }
           link {
-            href = "https://unpkg.com/swagger-ui-dist@$swaggerVersion/swagger-ui.css"
+            href = "https://unpkg.com/swagger-ui-dist$swaggerVersionSuffix/swagger-ui.css"
             rel = "stylesheet"
           }
         }
@@ -54,10 +56,10 @@ fun Route.swagger(
             id = "swagger-ui"
           }
           script {
-            src = "https://unpkg.com/swagger-ui-dist@$swaggerVersion/swagger-ui-standalone-preset.js"
+            src = "https://unpkg.com/swagger-ui-dist$swaggerVersionSuffix/swagger-ui-standalone-preset.js"
           }
           script {
-            src = "https://unpkg.com/swagger-ui-dist@$swaggerVersion/swagger-ui-bundle.js"
+            src = "https://unpkg.com/swagger-ui-dist$swaggerVersionSuffix/swagger-ui-bundle.js"
           }
           unsafe {
             +"""

--- a/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt
@@ -1,0 +1,89 @@
+package io.bkbn.kompendium.core.routes
+
+import io.ktor.server.application.call
+import io.ktor.server.html.respondHtml
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import kotlinx.html.body
+import kotlinx.html.div
+import kotlinx.html.head
+import kotlinx.html.id
+import kotlinx.html.link
+import kotlinx.html.meta
+import kotlinx.html.script
+import kotlinx.html.title
+import kotlinx.html.unsafe
+
+/**
+ * Provides an out-of-the-box route to view docs using Swagger
+ * @see <a href="https://swagger.io/specification/">Swagger OpenApi Specification</a>
+ * for the latest supported open api version.
+ * @param pageTitle Webpage title you wish to be displayed on your docs
+ * @param path path to docs resource
+ * @param specUrl url to point Swagger to the OpenAPI json document
+ * @param swaggerVersion version of swagger-ui distribution
+ */
+fun Route.swagger(
+  pageTitle: String = "Docs",
+  path: String = "/swagger-ui",
+  specUrl: String = "/openapi.json",
+  swaggerVersion: String = "4.17.0"
+) {
+  route(path) {
+    get {
+      call.respondHtml {
+        head {
+          title {
+            +pageTitle
+          }
+          meta {
+            charset = "utf-8"
+          }
+          meta {
+            name = "viewport"
+            content = "width=device-width, initial-scale=1"
+          }
+          link {
+            href = "https://unpkg.com/swagger-ui-dist@$swaggerVersion/swagger-ui.css"
+            rel = "stylesheet"
+          }
+        }
+        body {
+          div {
+            id = "swagger-ui"
+          }
+          script {
+            src = "https://unpkg.com/swagger-ui-dist@$swaggerVersion/swagger-ui-standalone-preset.js"
+          }
+          script {
+            src = "https://unpkg.com/swagger-ui-dist@$swaggerVersion/swagger-ui-bundle.js"
+          }
+          unsafe {
+            +"""
+              <script>
+                window.onload = function () {
+                  // Build a system
+                  const ui = SwaggerUIBundle({
+                    url: "$specUrl",
+                    dom_id: '#swagger-ui',
+                    deepLinking: true,
+                    presets: [
+                      SwaggerUIBundle.presets.apis,
+                      SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                      SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                    layout: "StandaloneLayout",
+                  })
+                  window.ui = ui
+                }
+              </script>
+            """.trimIndent()
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestHelpers.kt
+++ b/core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestHelpers.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import io.bkbn.kompendium.core.fixtures.TestSpecs.defaultSpec
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.KotlinXSchemaConfigurator
 import io.bkbn.kompendium.json.schema.definition.JsonSchema
 import io.bkbn.kompendium.oas.OpenApiSpec
@@ -130,6 +131,7 @@ object TestHelpers {
     }
     application(applicationSetup)
     routing {
+      swagger()
       redoc()
       routeUnderTest()
     }

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/AuthPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/AuthPlayground.kt
@@ -4,6 +4,7 @@ import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.plugin.NotarizedRoute
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.oas.component.Components
 import io.bkbn.kompendium.oas.payload.Parameter
@@ -68,6 +69,7 @@ private fun Application.mainModule() {
     )
   }
   routing {
+    swagger(pageTitle = "Simple API Docs")
     redoc(pageTitle = "Simple API Docs")
     authenticate("basic") {
       route("/{id}") {

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/BasicPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/BasicPlayground.kt
@@ -4,6 +4,7 @@ import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.plugin.NotarizedRoute
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.KotlinXSchemaConfigurator
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.oas.payload.Parameter
@@ -49,6 +50,7 @@ private fun Application.mainModule() {
     schemaConfigurator = KotlinXSchemaConfigurator()
   }
   routing {
+    swagger(pageTitle = "Simple API Docs")
     redoc(pageTitle = "Simple API Docs")
     route("/{id}") {
       idDocumentation()

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/CustomTypePlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/CustomTypePlayground.kt
@@ -4,6 +4,7 @@ import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.plugin.NotarizedRoute
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.oas.payload.Parameter
 import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
@@ -51,6 +52,7 @@ private fun Application.mainModule() {
     )
   }
   routing {
+    swagger(pageTitle = "Simple API Docs")
     redoc(pageTitle = "Simple API Docs")
 
     route("/{id}") {

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/EnrichmentPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/EnrichmentPlayground.kt
@@ -5,6 +5,7 @@ import io.bkbn.kompendium.core.metadata.PostInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.plugin.NotarizedRoute
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.enrichment.TypeEnrichment
 import io.bkbn.kompendium.json.schema.KotlinXSchemaConfigurator
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
@@ -50,6 +51,7 @@ private fun Application.mainModule() {
     schemaConfigurator = KotlinXSchemaConfigurator()
   }
   routing {
+    swagger(pageTitle = "Simple API Docs")
     redoc(pageTitle = "Simple API Docs")
     enrichedDocumentation()
     post {

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/ExceptionPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/ExceptionPlayground.kt
@@ -4,6 +4,7 @@ import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.plugin.NotarizedRoute
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.oas.payload.Parameter
 import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
@@ -50,6 +51,7 @@ private fun Application.mainModule() {
     }
   }
   routing {
+    swagger(pageTitle = "Simple API Docs")
     redoc(pageTitle = "Simple API Docs")
 
     route("/{id}") {

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/GsonSerializationPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/GsonSerializationPlayground.kt
@@ -6,6 +6,7 @@ import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.plugin.NotarizedRoute
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.SchemaConfigurator
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.oas.payload.Parameter
@@ -48,6 +49,7 @@ private fun Application.mainModule() {
     schemaConfigurator = GsonSchemaConfigurator()
   }
   routing {
+    swagger(pageTitle = "Simple API Docs")
     redoc(pageTitle = "Simple API Docs")
 
     route("/{id}") {

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/HiddenDocsPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/HiddenDocsPlayground.kt
@@ -5,6 +5,7 @@ import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.plugin.NotarizedRoute
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.oas.component.Components
 import io.bkbn.kompendium.oas.payload.Parameter
@@ -80,6 +81,7 @@ private fun Application.mainModule() {
   }
   routing {
     authenticate("basic") {
+      swagger(pageTitle = "Simple API Docs")
       redoc(pageTitle = "Simple API Docs")
       route("/{id}") {
         locationDocumentation()

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/JacksonSerializationPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/JacksonSerializationPlayground.kt
@@ -8,6 +8,7 @@ import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.plugin.NotarizedRoute
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.SchemaConfigurator
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.oas.payload.Parameter
@@ -51,6 +52,7 @@ private fun Application.mainModule() {
     schemaConfigurator = JacksonSchemaConfigurator()
   }
   routing {
+    swagger(pageTitle = "Simple API Docs")
     redoc(pageTitle = "Simple API Docs")
 
     route("/{id}") {

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/LocationPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/LocationPlayground.kt
@@ -3,6 +3,7 @@ package io.bkbn.kompendium.playground
 import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.locations.NotarizedLocations
 import io.bkbn.kompendium.oas.payload.Parameter
@@ -72,6 +73,7 @@ private fun Application.mainModule() {
     )
   }
   routing {
+    swagger(pageTitle = "Simple API Docs")
     redoc(pageTitle = "Simple API Docs")
     get<Listing> { listing ->
       call.respondText("Listing ${listing.name}, page ${listing.page}")

--- a/playground/src/main/kotlin/io/bkbn/kompendium/playground/ResourcesPlayground.kt
+++ b/playground/src/main/kotlin/io/bkbn/kompendium/playground/ResourcesPlayground.kt
@@ -3,6 +3,7 @@ package io.bkbn.kompendium.playground
 import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
 import io.bkbn.kompendium.core.routes.redoc
+import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.oas.payload.Parameter
 import io.bkbn.kompendium.oas.serialization.KompendiumSerializersModule
@@ -73,6 +74,7 @@ private fun Application.mainModule() {
     )
   }
   routing {
+    swagger(pageTitle = "Simple API Docs")
     redoc(pageTitle = "Simple API Docs")
     get<ListingResource> { listing ->
       call.respondText("Listing ${listing.name}, page ${listing.page}")


### PR DESCRIPTION
# Description

Reintroduce swagger functionality that existed in v2.3.5 but was removed in v3.0.0. See [Swagger.kt@2.3.5](https://github.com/bkbnio/kompendium/blob/v2.3.5/kompendium-core/src/main/kotlin/io/bkbn/kompendium/core/routes/Swagger.kt)

Closes # (issue)

[425](https://github.com/bkbnio/kompendium/issues/425)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
