### PR TITLE
fix: References for for protobuf objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Components definitions were not in the proper schema section. Prefixed the path with component slug in `protobuf java converter`.
+
 ### Remove
 
 ---

--- a/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/util/Helpers.kt
+++ b/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/util/Helpers.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KType
 
 object Helpers {
 
-  private const val COMPONENT_SLUG = "#/components/schemas"
+  const val COMPONENT_SLUG = "#/components/schemas"
 
   fun KType.getSlug(enrichment: Enrichment? = null) = when (enrichment) {
     is TypeEnrichment<*> -> getEnrichedSlug(enrichment)

--- a/protobuf-java-converter/src/main/kotlin/io/bkbn/kompendium/protobufjavaconverter/converters/FieldDescriptiorConverters.kt
+++ b/protobuf-java-converter/src/main/kotlin/io/bkbn/kompendium/protobufjavaconverter/converters/FieldDescriptiorConverters.kt
@@ -9,6 +9,7 @@ import io.bkbn.kompendium.json.schema.definition.MapDefinition
 import io.bkbn.kompendium.json.schema.definition.NullableDefinition
 import io.bkbn.kompendium.json.schema.definition.ReferenceDefinition
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
+import io.bkbn.kompendium.json.schema.util.Helpers
 import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 
@@ -150,7 +151,7 @@ fun fromTypeToSchema(
         type = "string",
         enum = javaProtoField.enumType.values.map { it.name }.toSet()
       )
-      ReferenceDefinition(javaProtoField.enumType.name)
+      ReferenceDefinition("${Helpers.COMPONENT_SLUG}/${javaProtoField.enumType.name}")
     }
     Descriptors.FieldDescriptor.JavaType.MESSAGE -> {
       // Traverse through possible nested messages
@@ -160,7 +161,7 @@ fun fromTypeToSchema(
           it.jsonName to fromNestedTypeToSchema(it, cache)
         }.toMap()
       )
-      ReferenceDefinition(javaProtoField.messageType.name)
+      ReferenceDefinition("${Helpers.COMPONENT_SLUG}/${javaProtoField.messageType.name}")
     }
     null -> NullableDefinition()
   }

--- a/protobuf-java-converter/src/test/resources/T0001__simpletestmessage_post.json
+++ b/protobuf-java-converter/src/test/resources/T0001__simpletestmessage_post.json
@@ -1,0 +1,127 @@
+{
+  "openapi": "3.1.0",
+  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+  "info": {
+    "title": "Test API",
+    "version": "1.33.7",
+    "description": "An amazing, fully-ish 😉 generated API spec",
+    "termsOfService": "https://example.com",
+    "contact": {
+      "name": "Homer Simpson",
+      "url": "https://gph.is/1NPUDiM",
+      "email": "chunkylover53@aol.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/bkbnio/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://myawesomeapi.com",
+      "description": "Production instance of my API"
+    },
+    {
+      "url": "https://staging.myawesomeapi.com",
+      "description": "Where the fun stuff happens"
+    }
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "tags": [],
+        "summary": "Great Summary!",
+        "description": "testing more",
+        "parameters": [],
+        "requestBody": {
+          "description": "You gotta send it",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A Successful Endeavor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SimpleTestMessage"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "parameters": []
+    }
+  },
+  "webhooks": {},
+  "components": {
+    "schemas": {
+      "SimpleTestMessage": {
+        "type": "object",
+        "properties": {
+          "myTestDouble": {
+            "type": "number",
+            "format": "double"
+          },
+          "myTestFloat": {
+            "type": "number",
+            "format": "float"
+          },
+          "myTestInt32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestInt64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestUint32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestUint64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestSint32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestSint64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestFixed32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestFixed64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestSfixed32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestSfixed64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestBool": {
+            "type": "boolean"
+          },
+          "myTestBytes": {
+            "type": "string"
+          },
+          "myTestString": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": []
+}

--- a/protobuf-java-converter/src/test/resources/T0002__enummessage_post.json
+++ b/protobuf-java-converter/src/test/resources/T0002__enummessage_post.json
@@ -1,0 +1,86 @@
+{
+  "openapi": "3.1.0",
+  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+  "info": {
+    "title": "Test API",
+    "version": "1.33.7",
+    "description": "An amazing, fully-ish 😉 generated API spec",
+    "termsOfService": "https://example.com",
+    "contact": {
+      "name": "Homer Simpson",
+      "url": "https://gph.is/1NPUDiM",
+      "email": "chunkylover53@aol.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/bkbnio/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://myawesomeapi.com",
+      "description": "Production instance of my API"
+    },
+    {
+      "url": "https://staging.myawesomeapi.com",
+      "description": "Where the fun stuff happens"
+    }
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "tags": [],
+        "summary": "Great Summary!",
+        "description": "testing more",
+        "parameters": [],
+        "requestBody": {
+          "description": "You gotta send it",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A Successful Endeavor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnumMessage"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "parameters": []
+    }
+  },
+  "webhooks": {},
+  "components": {
+    "schemas": {
+      "EnumMessage": {
+        "type": "object",
+        "properties": {
+          "corpus": {
+            "$ref": "#/components/schemas/Corpus"
+          }
+        }
+      },
+      "Corpus": {
+        "type": "string",
+        "enum": [
+          "CORPUS_UNSPECIFIED",
+          "CORPUS_UNIVERSAL",
+          "CORPUS_WEB",
+          "CORPUS_IMAGES",
+          "CORPUS_LOCAL",
+          "CORPUS_NEWS",
+          "CORPUS_PRODUCTS",
+          "CORPUS_VIDEO"
+        ]
+      }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": []
+}

--- a/protobuf-java-converter/src/test/resources/T0003__repeatedmessage_post.json
+++ b/protobuf-java-converter/src/test/resources/T0003__repeatedmessage_post.json
@@ -1,0 +1,138 @@
+{
+  "openapi": "3.1.0",
+  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+  "info": {
+    "title": "Test API",
+    "version": "1.33.7",
+    "description": "An amazing, fully-ish 😉 generated API spec",
+    "termsOfService": "https://example.com",
+    "contact": {
+      "name": "Homer Simpson",
+      "url": "https://gph.is/1NPUDiM",
+      "email": "chunkylover53@aol.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/bkbnio/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://myawesomeapi.com",
+      "description": "Production instance of my API"
+    },
+    {
+      "url": "https://staging.myawesomeapi.com",
+      "description": "Where the fun stuff happens"
+    }
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "tags": [],
+        "summary": "Great Summary!",
+        "description": "testing more",
+        "parameters": [],
+        "requestBody": {
+          "description": "You gotta send it",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A Successful Endeavor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepeatedMessage"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "parameters": []
+    }
+  },
+  "webhooks": {},
+  "components": {
+    "schemas": {
+      "RepeatedMessage": {
+        "type": "object",
+        "properties": {
+          "repeatedField": {
+            "items": {
+              "$ref": "#/components/schemas/SimpleTestMessage"
+            },
+            "type": "array"
+          }
+        }
+      },
+      "SimpleTestMessage": {
+        "type": "object",
+        "properties": {
+          "myTestDouble": {
+            "type": "number",
+            "format": "double"
+          },
+          "myTestFloat": {
+            "type": "number",
+            "format": "float"
+          },
+          "myTestInt32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestInt64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestUint32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestUint64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestSint32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestSint64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestFixed32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestFixed64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestSfixed32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestSfixed64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestBool": {
+            "type": "boolean"
+          },
+          "myTestBytes": {
+            "type": "string"
+          },
+          "myTestString": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": []
+}

--- a/protobuf-java-converter/src/test/resources/T0004__nestedmessage_post.json
+++ b/protobuf-java-converter/src/test/resources/T0004__nestedmessage_post.json
@@ -1,0 +1,135 @@
+{
+  "openapi": "3.1.0",
+  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+  "info": {
+    "title": "Test API",
+    "version": "1.33.7",
+    "description": "An amazing, fully-ish 😉 generated API spec",
+    "termsOfService": "https://example.com",
+    "contact": {
+      "name": "Homer Simpson",
+      "url": "https://gph.is/1NPUDiM",
+      "email": "chunkylover53@aol.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/bkbnio/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://myawesomeapi.com",
+      "description": "Production instance of my API"
+    },
+    {
+      "url": "https://staging.myawesomeapi.com",
+      "description": "Where the fun stuff happens"
+    }
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "tags": [],
+        "summary": "Great Summary!",
+        "description": "testing more",
+        "parameters": [],
+        "requestBody": {
+          "description": "You gotta send it",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A Successful Endeavor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NestedMessage"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "parameters": []
+    }
+  },
+  "webhooks": {},
+  "components": {
+    "schemas": {
+      "NestedMessage": {
+        "type": "object",
+        "properties": {
+          "nestedField": {
+            "$ref": "#/components/schemas/SimpleTestMessage"
+          }
+        }
+      },
+      "SimpleTestMessage": {
+        "type": "object",
+        "properties": {
+          "myTestDouble": {
+            "type": "number",
+            "format": "double"
+          },
+          "myTestFloat": {
+            "type": "number",
+            "format": "float"
+          },
+          "myTestInt32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestInt64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestUint32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestUint64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestSint32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestSint64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestFixed32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestFixed64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestSfixed32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestSfixed64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestBool": {
+            "type": "boolean"
+          },
+          "myTestBytes": {
+            "type": "string"
+          },
+          "myTestString": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": []
+}

--- a/protobuf-java-converter/src/test/resources/T0005__nestedmapmessage_post.json
+++ b/protobuf-java-converter/src/test/resources/T0005__nestedmapmessage_post.json
@@ -1,0 +1,146 @@
+{
+  "openapi": "3.1.0",
+  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+  "info": {
+    "title": "Test API",
+    "version": "1.33.7",
+    "description": "An amazing, fully-ish 😉 generated API spec",
+    "termsOfService": "https://example.com",
+    "contact": {
+      "name": "Homer Simpson",
+      "url": "https://gph.is/1NPUDiM",
+      "email": "chunkylover53@aol.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/bkbnio/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://myawesomeapi.com",
+      "description": "Production instance of my API"
+    },
+    {
+      "url": "https://staging.myawesomeapi.com",
+      "description": "Where the fun stuff happens"
+    }
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "tags": [],
+        "summary": "Great Summary!",
+        "description": "testing more",
+        "parameters": [],
+        "requestBody": {
+          "description": "You gotta send it",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A Successful Endeavor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NestedMapMessage"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "parameters": []
+    }
+  },
+  "webhooks": {},
+  "components": {
+    "schemas": {
+      "NestedMapMessage": {
+        "type": "object",
+        "properties": {
+          "mapField": {
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "myVariable0": {
+                  "$ref": "#/components/schemas/SimpleTestMessage"
+                },
+                "myVariable1": {
+                  "$ref": "#/components/schemas/SimpleTestMessage"
+                }
+              }
+            },
+            "type": "object"
+          }
+        }
+      },
+      "SimpleTestMessage": {
+        "type": "object",
+        "properties": {
+          "myTestDouble": {
+            "type": "number",
+            "format": "double"
+          },
+          "myTestFloat": {
+            "type": "number",
+            "format": "float"
+          },
+          "myTestInt32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestInt64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestUint32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestUint64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestSint32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestSint64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestFixed32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestFixed64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestSfixed32": {
+            "type": "number",
+            "format": "int32"
+          },
+          "myTestSfixed64": {
+            "type": "number",
+            "format": "int64"
+          },
+          "myTestBool": {
+            "type": "boolean"
+          },
+          "myTestBytes": {
+            "type": "string"
+          },
+          "myTestString": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": []
+}


### PR DESCRIPTION
# Description

We were creating references without prefix them with `#/components/schemas` which was causing problems when trying to generate redoc.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation 
- [ ] Chore

# How Has This Been Tested?

Update and ran  tests locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have updated the CHANGELOG in the `Unreleased` section
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
