### PR TITLE
Feat added required parameter in request info builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Added
 
-### Changed
+- Added `required` parameter in request info builder.
 
-- Route generation with parameters doesn`t add parameters to the path.
+### Changed
 
 ### Remove
 

--- a/core/src/main/kotlin/io/bkbn/kompendium/core/metadata/RequestInfo.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/metadata/RequestInfo.kt
@@ -10,7 +10,8 @@ class RequestInfo private constructor(
   val typeEnrichment: TypeEnrichment<*>?,
   val description: String,
   val examples: Map<String, MediaType.Example>?,
-  val mediaTypes: Set<String>
+  val mediaTypes: Set<String>,
+  val required: Boolean
 ) {
 
   companion object {
@@ -27,6 +28,11 @@ class RequestInfo private constructor(
     private var description: String? = null
     private var examples: Map<String, MediaType.Example>? = null
     private var mediaTypes: Set<String>? = null
+    private var required: Boolean? = null
+
+    fun required(r: Boolean) = apply {
+      this.required = r
+    }
 
     fun requestType(t: KType) = apply {
       this.requestType = t
@@ -56,7 +62,8 @@ class RequestInfo private constructor(
       description = description ?: error("Description must be present"),
       typeEnrichment = typeEnrichment,
       examples = examples,
-      mediaTypes = mediaTypes ?: setOf("application/json")
+      mediaTypes = mediaTypes ?: setOf("application/json"),
+      required = required ?: true
     )
   }
 }

--- a/core/src/main/kotlin/io/bkbn/kompendium/core/util/Helpers.kt
+++ b/core/src/main/kotlin/io/bkbn/kompendium/core/util/Helpers.kt
@@ -131,7 +131,7 @@ object Helpers {
             mediaTypes = reqInfo.mediaTypes,
             enrichment = reqInfo.typeEnrichment
           ),
-          required = true
+          required = reqInfo.required
         )
       }
 

--- a/core/src/test/kotlin/io/bkbn/kompendium/core/KompendiumTest.kt
+++ b/core/src/test/kotlin/io/bkbn/kompendium/core/KompendiumTest.kt
@@ -52,6 +52,7 @@ import io.bkbn.kompendium.core.util.polymorphicResponse
 import io.bkbn.kompendium.core.util.postNoReqBody
 import io.bkbn.kompendium.core.util.primitives
 import io.bkbn.kompendium.core.util.reqRespExamples
+import io.bkbn.kompendium.core.util.optionalReqExample
 import io.bkbn.kompendium.core.util.requiredParams
 import io.bkbn.kompendium.core.util.responseHeaders
 import io.bkbn.kompendium.core.util.returnsList
@@ -177,6 +178,9 @@ class KompendiumTest : DescribeSpec({
     }
     it("Can describe example parameters") {
       openApiTestAllSerializers("T0021__example_parameters.json") { exampleParams() }
+    }
+    it("Can generate example optional request body") {
+      openApiTestAllSerializers("T0069__example_optional_req.json") { optionalReqExample() }
     }
   }
   describe("Defaults") {

--- a/core/src/test/kotlin/io/bkbn/kompendium/core/util/Examples.kt
+++ b/core/src/test/kotlin/io/bkbn/kompendium/core/util/Examples.kt
@@ -29,6 +29,7 @@ fun Routing.reqRespExamples() {
           examples(
             "Testerina" to TestRequest(TestNested("asdf"), 1.5, emptyList())
           )
+          required(false)
         }
         response {
           description(defaultResponseDescription)

--- a/core/src/test/kotlin/io/bkbn/kompendium/core/util/Examples.kt
+++ b/core/src/test/kotlin/io/bkbn/kompendium/core/util/Examples.kt
@@ -29,7 +29,6 @@ fun Routing.reqRespExamples() {
           examples(
             "Testerina" to TestRequest(TestNested("asdf"), 1.5, emptyList())
           )
-          required(false)
         }
         response {
           description(defaultResponseDescription)

--- a/core/src/test/kotlin/io/bkbn/kompendium/core/util/Examples.kt
+++ b/core/src/test/kotlin/io/bkbn/kompendium/core/util/Examples.kt
@@ -55,3 +55,30 @@ fun Routing.exampleParams() = basicGetGenerator<TestResponse>(
     )
   )
 )
+
+fun Routing.optionalReqExample() {
+  route(rootPath) {
+    install(NotarizedRoute()) {
+      post = PostInfo.builder {
+        summary(defaultPathSummary)
+        description(defaultPathDescription)
+        request {
+          description(defaultRequestDescription)
+          requestType<TestRequest>()
+          examples(
+            "Testerina" to TestRequest(TestNested("asdf"), 1.5, emptyList())
+          )
+          required(false)
+        }
+        response {
+          description(defaultResponseDescription)
+          responseCode(HttpStatusCode.OK)
+          responseType<TestResponse>()
+          examples(
+            "Testerino" to TestResponse("Heya")
+          )
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/resources/T0020__example_req_and_resp.json
+++ b/core/src/test/resources/T0020__example_req_and_resp.json
@@ -53,7 +53,7 @@
               }
             }
           },
-          "required": false
+          "required": true
         },
         "responses": {
           "200": {

--- a/core/src/test/resources/T0020__example_req_and_resp.json
+++ b/core/src/test/resources/T0020__example_req_and_resp.json
@@ -53,7 +53,7 @@
               }
             }
           },
-          "required": true
+          "required": false
         },
         "responses": {
           "200": {

--- a/core/src/test/resources/T0069__example_optional_req.json
+++ b/core/src/test/resources/T0069__example_optional_req.json
@@ -1,0 +1,136 @@
+{
+  "openapi": "3.1.0",
+  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+  "info": {
+    "title": "Test API",
+    "version": "1.33.7",
+    "description": "An amazing, fully-ish 😉 generated API spec",
+    "termsOfService": "https://example.com",
+    "contact": {
+      "name": "Homer Simpson",
+      "url": "https://gph.is/1NPUDiM",
+      "email": "chunkylover53@aol.com"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/bkbnio/kompendium/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://myawesomeapi.com",
+      "description": "Production instance of my API"
+    },
+    {
+      "url": "https://staging.myawesomeapi.com",
+      "description": "Where the fun stuff happens"
+    }
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "tags": [],
+        "summary": "Great Summary!",
+        "description": "testing more",
+        "parameters": [],
+        "requestBody": {
+          "description": "You gotta send it",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestRequest"
+              },
+              "examples": {
+                "Testerina": {
+                  "value": {
+                    "fieldName": {
+                      "nesty": "asdf"
+                    },
+                    "b": 1.5,
+                    "aaa": []
+                  }
+                }
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "A Successful Endeavor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestResponse"
+                },
+                "examples": {
+                  "Testerino": {
+                    "value": {
+                      "c": "Heya"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      },
+      "parameters": []
+    }
+  },
+  "webhooks": {},
+  "components": {
+    "schemas": {
+      "TestResponse": {
+        "type": "object",
+        "properties": {
+          "c": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "c"
+        ]
+      },
+      "TestRequest": {
+        "type": "object",
+        "properties": {
+          "aaa": {
+            "items": {
+              "type": "number",
+              "format": "int64"
+            },
+            "type": "array"
+          },
+          "b": {
+            "type": "number",
+            "format": "double"
+          },
+          "fieldName": {
+            "$ref": "#/components/schemas/TestNested"
+          }
+        },
+        "required": [
+          "aaa",
+          "b",
+          "fieldName"
+        ]
+      },
+      "TestNested": {
+        "type": "object",
+        "properties": {
+          "nesty": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "nesty"
+        ]
+      }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": []
+}


### PR DESCRIPTION
Hi, in my project I needed to make the request body optional so that the open api does not require it to send the request.

To do this, I added a new parameter to request info and its builder. Then I substituted it into the creation of the Request class. I saw that previously required was true and in order not to break existing projects, I made true the default value.

I hope my solution will work.