### PR TITLE
feat: automatically inject type identifier for sealed interfaces when using ktx serialization configurator

### DIFF
--- a/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/KotlinXSchemaConfigurator.kt
+++ b/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/KotlinXSchemaConfigurator.kt
@@ -1,9 +1,14 @@
 package io.bkbn.kompendium.json.schema
 
+import io.bkbn.kompendium.json.schema.definition.EnumDefinition
+import io.bkbn.kompendium.json.schema.definition.JsonSchema
+import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Transient
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
+import kotlin.reflect.KType
+import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.memberProperties
 
@@ -17,4 +22,28 @@ class KotlinXSchemaConfigurator : SchemaConfigurator {
     property.annotations
       .filterIsInstance<SerialName>()
       .firstOrNull()?.value ?: property.name
+
+  override fun sealedTypeEnrichment(
+    implementationType: KType,
+    implementationSchema: JsonSchema,
+  ): JsonSchema {
+    return if (implementationSchema is TypeDefinition && implementationSchema.type == "object") {
+      implementationSchema.copy(
+        required = implementationSchema.required?.plus("type"),
+        properties = implementationSchema.properties?.plus(
+          mapOf(
+            "type" to EnumDefinition("string", enum = setOf(determineTypeQualifier(implementationType)))
+          )
+        )
+      )
+    } else {
+      implementationSchema
+    }
+  }
+
+  private fun determineTypeQualifier(type: KType): String {
+    val nameOverrideAnnotation = type.findAnnotation<SerialName>()
+    // TODO Cleaner way to get fqcn?
+    return nameOverrideAnnotation?.value ?: type.classifier.toString().replace("class ", "")
+  }
 }

--- a/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/SchemaConfigurator.kt
+++ b/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/SchemaConfigurator.kt
@@ -1,12 +1,19 @@
 package io.bkbn.kompendium.json.schema
 
+import io.bkbn.kompendium.json.schema.definition.JsonSchema
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
+import kotlin.reflect.KType
 import kotlin.reflect.full.memberProperties
 
 interface SchemaConfigurator {
   fun serializableMemberProperties(clazz: KClass<*>): Collection<KProperty1<out Any, *>>
   fun serializableName(property: KProperty1<out Any, *>): String
+
+  fun sealedTypeEnrichment(
+    implementationType: KType,
+    implementationSchema: JsonSchema
+  ): JsonSchema = implementationSchema
 
   open class Default : SchemaConfigurator {
     override fun serializableMemberProperties(clazz: KClass<*>): Collection<KProperty1<out Any, *>> =

--- a/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/handler/SealedObjectHandler.kt
+++ b/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/handler/SealedObjectHandler.kt
@@ -25,15 +25,18 @@ object SealedObjectHandler {
     val subclasses = clazz.sealedSubclasses
       .map { it.createType(type.arguments) }
       .map { t ->
-        SchemaGenerator.fromTypeToSchema(t, cache, schemaConfigurator, enrichment).let { js ->
-          if (js is TypeDefinition && js.type == "object") {
-            val slug = t.getSlug(enrichment)
-            cache[slug] = js
-            ReferenceDefinition(t.getReferenceSlug(enrichment))
-          } else {
-            js
+        SchemaGenerator.fromTypeToSchema(t, cache, schemaConfigurator, enrichment)
+          .let {
+            schemaConfigurator.sealedTypeEnrichment(t, it)
+          }.let { js ->
+            if (js is TypeDefinition && js.type == "object") {
+              val slug = t.getSlug(enrichment)
+              cache[slug] = js
+              ReferenceDefinition(t.getReferenceSlug(enrichment))
+            } else {
+              js
+            }
           }
-        }
       }
       .toSet()
     return AnyOfDefinition(subclasses)


### PR DESCRIPTION
# Description

Will automatically inject the `type` field for implementations of sealed interfaces.

Closes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation 
- [ ] Chore

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated the CHANGELOG in the `Unreleased` section
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
