### PR TITLE
fix: add missing mapping of BooleanEnrichment to EnrichmentHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changed
 
+### Fixed
+
+- Fixed missing `BooleanEnrichment` mapping
+
 ### Remove
 
 ---

--- a/core/src/test/kotlin/io/bkbn/kompendium/core/util/Enrichment.kt
+++ b/core/src/test/kotlin/io/bkbn/kompendium/core/util/Enrichment.kt
@@ -10,6 +10,7 @@ import io.bkbn.kompendium.core.fixtures.TestSimpleRequest
 import io.bkbn.kompendium.core.metadata.GetInfo
 import io.bkbn.kompendium.core.metadata.PostInfo
 import io.bkbn.kompendium.core.plugin.NotarizedRoute
+import io.bkbn.kompendium.enrichment.BooleanEnrichment
 import io.bkbn.kompendium.enrichment.CollectionEnrichment
 import io.bkbn.kompendium.enrichment.MapEnrichment
 import io.bkbn.kompendium.enrichment.NumberEnrichment
@@ -62,6 +63,9 @@ fun Route.enrichedSimpleRequest() {
                 NumberEnrichment("blah-blah-blah") {
                   deprecated = true
                 }
+              }
+              TestSimpleRequest::c {
+                BooleanEnrichment("blah-blah-blah") { }
               }
             }
           )

--- a/core/src/test/resources/T0002__notarized_post.json
+++ b/core/src/test/resources/T0002__notarized_post.json
@@ -109,11 +109,15 @@
           "b": {
             "type": "number",
             "format": "int32"
+          },
+          "c": {
+            "type": "boolean"
           }
         },
         "required": [
           "a",
-          "b"
+          "b",
+          "c"
         ]
       }
     },

--- a/core/src/test/resources/T0003__notarized_put.json
+++ b/core/src/test/resources/T0003__notarized_put.json
@@ -109,11 +109,15 @@
           "b": {
             "type": "number",
             "format": "int32"
+          },
+          "c": {
+            "type": "boolean"
           }
         },
         "required": [
           "a",
-          "b"
+          "b",
+          "c"
         ]
       }
     },

--- a/core/src/test/resources/T0005__notarized_patch.json
+++ b/core/src/test/resources/T0005__notarized_patch.json
@@ -109,11 +109,15 @@
           "b": {
             "type": "number",
             "format": "int32"
+          },
+          "c": {
+            "type": "boolean"
           }
         },
         "required": [
           "a",
-          "b"
+          "b",
+          "c"
         ]
       }
     },

--- a/core/src/test/resources/T0053__same_path_different_methods_and_auth.json
+++ b/core/src/test/resources/T0053__same_path_different_methods_and_auth.json
@@ -144,11 +144,15 @@
           "b": {
             "type": "number",
             "format": "int32"
+          },
+          "c": {
+            "type": "boolean"
           }
         },
         "required": [
           "a",
-          "b"
+          "b",
+          "c"
         ]
       }
     },

--- a/core/src/test/resources/T0055__enriched_simple_request.json
+++ b/core/src/test/resources/T0055__enriched_simple_request.json
@@ -111,11 +111,15 @@
             "type": "number",
             "format": "int32",
             "deprecated": true
+          },
+          "c": {
+            "type": "boolean"
           }
         },
         "required": [
           "a",
-          "b"
+          "b",
+          "c"
         ]
       }
     },

--- a/core/src/test/resources/T0067__enriched_generic_object.json
+++ b/core/src/test/resources/T0067__enriched_generic_object.json
@@ -76,11 +76,15 @@
             "type": "number",
             "format": "int32",
             "deprecated": true
+          },
+          "c": {
+            "type": "boolean"
           }
         },
         "required": [
           "a",
-          "b"
+          "b",
+          "c"
         ]
       }
     },

--- a/core/src/test/resources/T0077__enriched_top_level_list.json
+++ b/core/src/test/resources/T0077__enriched_top_level_list.json
@@ -111,11 +111,15 @@
             "type": "number",
             "format": "int32",
             "deprecated": true
+          },
+          "c": {
+            "type": "boolean"
           }
         },
         "required": [
           "a",
-          "b"
+          "b",
+          "c"
         ]
       },
       "TestSimpleRequest-blah-blah": {
@@ -129,11 +133,15 @@
             "type": "number",
             "format": "int32",
             "deprecated": true
+          },
+          "c": {
+            "type": "boolean"
           }
         },
         "required": [
           "a",
-          "b"
+          "b",
+          "c"
         ]
       },
       "List-TestSimpleRequest-blah-blah": {

--- a/core/src/test/resources/T0078__enriched_top_level_map.json
+++ b/core/src/test/resources/T0078__enriched_top_level_map.json
@@ -64,11 +64,15 @@
             "type": "number",
             "format": "int32",
             "deprecated": true
+          },
+          "c": {
+            "type": "boolean"
           }
         },
         "required": [
           "a",
-          "b"
+          "b",
+          "c"
         ]
       },
       "TestSimpleRequest-blah": {
@@ -82,11 +86,15 @@
             "type": "number",
             "format": "int32",
             "deprecated": true
+          },
+          "c": {
+            "type": "boolean"
           }
         },
         "required": [
           "a",
-          "b"
+          "b",
+          "c"
         ]
       },
       "Map-String-TestSimpleRequest-blah": {

--- a/core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestModels.kt
+++ b/core/src/testFixtures/kotlin/io/bkbn/kompendium/core/fixtures/TestModels.kt
@@ -23,7 +23,8 @@ data class TestRequest(
 @Serializable
 data class TestSimpleRequest(
   val a: String,
-  val b: Int
+  val b: Int,
+  val c: Boolean
 )
 
 @Serializable

--- a/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/handler/EnrichmentHandler.kt
+++ b/json-schema/src/main/kotlin/io/bkbn/kompendium/json/schema/handler/EnrichmentHandler.kt
@@ -1,5 +1,6 @@
 package io.bkbn.kompendium.json.schema.handler
 
+import io.bkbn.kompendium.enrichment.BooleanEnrichment
 import io.bkbn.kompendium.enrichment.CollectionEnrichment
 import io.bkbn.kompendium.enrichment.Enrichment
 import io.bkbn.kompendium.enrichment.MapEnrichment
@@ -15,6 +16,7 @@ import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 object EnrichmentHandler {
 
   fun Enrichment.applyToSchema(schema: JsonSchema): JsonSchema = when (this) {
+    is BooleanEnrichment -> applyToSchema(schema)
     is NumberEnrichment -> applyToSchema(schema)
     is StringEnrichment -> applyToSchema(schema)
     is CollectionEnrichment<*> -> applyToSchema(schema)
@@ -39,6 +41,11 @@ object EnrichmentHandler {
     else -> error("Incorrect enrichment type for enrichment id: ${this.id}")
   }
 
+  private fun BooleanEnrichment.applyToSchema(schema: JsonSchema): JsonSchema = when (schema) {
+    is TypeDefinition -> schema.copyBooleanEnrichment(this)
+    else -> error("Incorrect enrichment type for enrichment id: ${this.id}")
+  }
+
   private fun NumberEnrichment.applyToSchema(schema: JsonSchema): JsonSchema = when (schema) {
     is TypeDefinition -> schema.copyNumberEnrichment(this)
     else -> error("Incorrect enrichment type for enrichment id: ${this.id}")
@@ -48,6 +55,13 @@ object EnrichmentHandler {
     is TypeDefinition -> schema.copyStringEnrichment(this)
     else -> error("Incorrect enrichment type for enrichment id: ${this.id}")
   }
+
+  private fun TypeDefinition.copyBooleanEnrichment(
+    enrichment: BooleanEnrichment
+  ): TypeDefinition = copy(
+    deprecated = enrichment.deprecated,
+    description = enrichment.description,
+  )
 
   private fun TypeDefinition.copyNumberEnrichment(
     enrichment: NumberEnrichment

--- a/json-schema/src/test/resources/T0004__simple_object.json
+++ b/json-schema/src/test/resources/T0004__simple_object.json
@@ -7,10 +7,14 @@
     "b": {
       "type": "number",
       "format": "int32"
+    },
+    "c": {
+      "type": "boolean"
     }
   },
   "required": [
     "a",
-    "b"
+    "b",
+    "c"
   ]
 }

--- a/json-schema/src/test/resources/T0006__nullable_object.json
+++ b/json-schema/src/test/resources/T0006__nullable_object.json
@@ -7,10 +7,14 @@
     "b": {
       "type": "number",
       "format": "int32"
+    },
+    "c": {
+      "type": "boolean"
     }
   },
   "required": [
     "a",
-    "b"
+    "b",
+    "c"
   ]
 }

--- a/json-schema/src/test/resources/T0022__enriched_simple_object.json
+++ b/json-schema/src/test/resources/T0022__enriched_simple_object.json
@@ -9,10 +9,14 @@
       "type": "number",
       "format": "int32",
       "deprecated": true
+    },
+    "c": {
+      "type": "boolean"
     }
   },
   "required": [
     "a",
-    "b"
+    "b",
+    "c"
   ]
 }


### PR DESCRIPTION
# Description

We wanted to upgrade to version 4.0.2 and found out that the `BooleanEnrichment` in our project caused the error `Incorrect enrichment type for enrichment id: [...]`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation 
- [ ] Chore

# How Has This Been Tested?

- Added `BooleanEnrichment` property to existing test cases
- Tested the locally built version with our internal project which doesn't return the error anymore

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
