### PR TITLE
Fix some issues

### DIFF
--- a/oas/src/main/kotlin/io/bkbn/kompendium/oas/OpenApiSpec.kt
+++ b/oas/src/main/kotlin/io/bkbn/kompendium/oas/OpenApiSpec.kt
@@ -6,6 +6,8 @@ import io.bkbn.kompendium.oas.component.Components
 import io.bkbn.kompendium.oas.info.Info
 import io.bkbn.kompendium.oas.path.Path
 import io.bkbn.kompendium.oas.server.Server
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 
 /**
@@ -27,9 +29,12 @@ import kotlinx.serialization.Serializable
  * @param tags A list of tags used by the document with additional metadata.
  * @param externalDocs Additional external documentation.
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class OpenApiSpec(
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
   val openapi: String = "3.1.0",
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
   val jsonSchemaDialect: String = "https://json-schema.org/draft/2020-12/schema",
   val info: Info,
   val servers: MutableList<Server> = mutableListOf(),

--- a/resources/src/main/kotlin/io/bkbn/kompendium/resources/Helpers.kt
+++ b/resources/src/main/kotlin/io/bkbn/kompendium/resources/Helpers.kt
@@ -1,6 +1,11 @@
 package io.bkbn.kompendium.resources
 
-import io.ktor.resources.Resource
+import io.ktor.resources.*
+import io.ktor.server.application.*
+import io.ktor.server.resources.*
+import io.ktor.server.resources.Resources
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.serializer
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.hasAnnotation
@@ -18,4 +23,14 @@ fun KClass<*>.getResourcePathFromClass(): String {
   } else {
     parent.getResourcePathFromClass() + path
   }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+fun KClass<*>.getPathFromClass(application: Application): String {
+  findAnnotation<Resource>() ?: error("Cannot notarize a resource without annotating with @Resource")
+
+  val format = application.plugin(Resources).resourcesFormat
+  val serializer = format.serializersModule.serializer(this, emptyList(), false)
+  // ResourcesFormat does not encode the top level '/'
+  return '/' + format.encodeToPathPattern(serializer)
 }

--- a/resources/src/main/kotlin/io/bkbn/kompendium/resources/NotarizedResource.kt
+++ b/resources/src/main/kotlin/io/bkbn/kompendium/resources/NotarizedResource.kt
@@ -24,10 +24,8 @@ object NotarizedResource {
     on(InstallHook) {
       val route = it as? Route ?: return@on
       val spec = application.attributes[KompendiumAttributes.openApiSpec]
-      val routePath = route.calculateRoutePath()
       val authMethods = route.collectAuthMethods()
-      val resourcePath = T::class.getResourcePathFromClass()
-      val fullPath = "$routePath$resourcePath"
+      val fullPath = T::class.getPathFromClass(application)
 
       addToSpec(spec, fullPath, authMethods)
     }


### PR DESCRIPTION
- Fix missing openapi version field
- Fix json schema field missing
- Fix broken path calculation of NotarizedResource

# Description
This PR fixes the following issues
- swagger throws a parser error, when the openapi field is not serialized
- NotarizedResource currently uses its own route calculation logic, which seems to be broken, instead of `/music/auth/exchange` it calculated `//musicauthexchange`


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation 
- [ ] Chore

# How Has This Been Tested?

Create new unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
