### PR TITLE
Java 11+ support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support for older versions of Java runtime down to Java 11
+
 All notable changes to this project will be documented in this file.
 
 ## [4.0.3] - 2024-11-11

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import io.bkbn.sourdough.gradle.library.jvm.LibraryJvmPlugin
 import io.bkbn.sourdough.gradle.library.jvm.LibraryJvmExtension
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   kotlin("jvm") version "2.1.20" apply false
@@ -39,6 +40,14 @@ subprojects {
       developerName.set("Ryan Brink")
       developerEmail.set("admin@bkbn.io")
       sonatypeHost.set(SonatypeHost.CENTRAL_PORTAL)
+      jvmTarget = "11"
+    }
+  }
+
+  tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+    jvmTargetValidationMode.set(org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode.WARNING)
+    compilerOptions {
+      jvmTarget = JvmTarget.JVM_11
     }
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,9 +8,7 @@ include("json-schema")
 include("protobuf-java-converter")
 include("resources")
 
-run {
-  rootProject.children.forEach { it.name = "${rootProject.name}-${it.name}" }
-}
+rootProject.children.forEach { it.name = "${rootProject.name}-${it.name}" }
 
 // Feature Previews
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
# Description

Support running Kompendium on previous versions of JVM. I've chosen Java 11 as a target, because it's a minimal version of Java, which Ktor framework currently supports.

Closes #661.

## Type of change

Please delete options that are not relevant.

- [x] Build

# How Has This Been Tested?

Published `4.0.3-SNAPSHOT` to MavenLocal with `:publishToMavenLocal` task, consumed it in a sample Ktor app and started the app with JVM 11.

✅ The Gradle build didn't crash with:

```
Execution failed for task ':compileKotlin'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve io.bkbn:kompendium-core:4.0.3.
     Required by:
         root project :
      > Dependency resolution is looking for a library compatible with JVM runtime version 11, but 'io.bkbn:kompendium-core:4.0.3' is only compatible with JVM runtime version 21 or newer.
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have updated the CHANGELOG in the `Unreleased` section
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
